### PR TITLE
add bonds from genesis ui

### DIFF
--- a/transactions/dimiandre-bond.toml
+++ b/transactions/dimiandre-bond.toml
@@ -343,14 +343,6 @@ amount = "100"
 tpknam1qq6htjvkw25pcmgpfrnckj372nlplfxpj0w3l3rgwuyuvq43usgx7tuq6kg = "signam1qz0s3yqqv2xkr4305fqjhskx45a8rz50wz6kmy27m06umjs5kwn6lygktfqwdfct36rqw973yq0x8emjss74vhfwy03nrjmzz7r5pkqf5w8n74"
 
 [[bond]]
-source = "tpknam1qqm9tg8vh3mzdalq59j2q29p9cjaxe74cttz5ycphda3ucl8hgjx7nkapyx"
-validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
-amount = "1024"
-
-[bond.signatures]
-tpknam1qqm9tg8vh3mzdalq59j2q29p9cjaxe74cttz5ycphda3ucl8hgjx7nkapyx = "signam1qpaeqfrh8m8zrpnnrdv8nk0d9ffnn0zs272g72u2gq3ze359aqzsr950mcme9vtjx46puwmhkn7kchzjryaj76h345arf05q0tc79lstzs4qyr"
-
-[[bond]]
 source = "tpknam1qphdvk8vn8jehgdns8dvt0x9r324mxhheypxkmkr3m2yt88snfaex0mk5sq"
 validator = "tnam1qygz4sn400y9g90rt5jx6ja0wrcx3y7u0c0ue6dq"
 amount = "170"
@@ -1341,14 +1333,6 @@ amount = "1923"
 
 [bond.signatures]
 tpknam1qpf5xrsrsjc67f7e3ehh8cnw37dahzg76j2yrnxa5ggrrhn270wvvu5vqxl = "signam1qr34np420aqhsqnwahhnzrh0hfnhlhdymjxna7qdermmet33reqxk7j0ejx74mwn90lluekznvh03mgcnv7nuqtshczedvg4p04wjlqzymnlyw"
-
-[[bond]]
-source = "tpknam1qpwyvvd6eqj49mr2sp7l4lmdgf6rls8zy2nh7maqfvgrt64fy3ypgpnzm43"
-validator = "tnam1q9pt4hukg0ga362jq2slhg4tuf692zqqngzzz54k"
-amount = "105"
-
-[bond.signatures]
-tpknam1qpwyvvd6eqj49mr2sp7l4lmdgf6rls8zy2nh7maqfvgrt64fy3ypgpnzm43 = "signam1qqaac8vnzk330fyakqj57qdu84pcr465nfhtxj0gzqvdr56w2ltstty4uqeldps9vcneaptrxdrew5tt6gyyv3zp3kqssdcjmmg2gfsx834f9l"
 
 [[bond]]
 source = "tpknam1qpmew0u8ux0wknzneg7mvj7ndcqn39nv7sarygva4h6znq3geg76yxafp6p"

--- a/transactions/dimiandre-bond.toml
+++ b/transactions/dimiandre-bond.toml
@@ -1,0 +1,1439 @@
+[[bond]]
+source = "tpknam1qz69wrqpxcgnpdlcxhgjahs7mhn0zxgpczhmtnn6rw8xzs49s6nay4dmg20"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1341"
+
+[bond.signatures]
+tpknam1qz69wrqpxcgnpdlcxhgjahs7mhn0zxgpczhmtnn6rw8xzs49s6nay4dmg20 = "signam1qqsdhth4znt750j7yvcv8e7evgm33qaauv3p2trpa499qqdmfj3t9rq3jqqvza7vxfee5855xmggrqg3gfqdwjz9anzs7a0hfwfwaqqgv5mvqh"
+
+[[bond]]
+source = "tpknam1qzdknxn2mr6s0sqltt5lgsz9fda9ssff778fgezrkg5aqzzh5jf0w4e40uw"
+validator = "tnam1qyx2vmne6th0nfk9lnwdz3mpwzslsaj5xc0x8ucu"
+amount = "100"
+
+[bond.signatures]
+tpknam1qzdknxn2mr6s0sqltt5lgsz9fda9ssff778fgezrkg5aqzzh5jf0w4e40uw = "signam1qrffmm8esw47st9ukf5f3y2k5q5mchwddz0zrrqfrhr9ds6j9tr3xn65zuw5ksu5zmjs67jdzv967mmn8cv562lcfrhkkz7m495g25c9z6gff2"
+
+[[bond]]
+source = "tpknam1qzf5scxn8q44pw0xs9pxp7vsxcvel3t4d9hw0t3hrkxc7xhduyq3yvp9rg8"
+validator = "tnam1qx7xenrcve38c8lmcmewpk42df6pchlyjg34d3lq"
+amount = "1113"
+
+[bond.signatures]
+tpknam1qzf5scxn8q44pw0xs9pxp7vsxcvel3t4d9hw0t3hrkxc7xhduyq3yvp9rg8 = "signam1qqe9w48u9mz0vkxq8kfytdjf2l82azw0htdqlage99rmr8uw8jh02tpvslce33eal4ka5srt53nx9gzjsyajry78md4hp8vctqqd33sfx9968g"
+
+[[bond]]
+source = "tpknam1qprnz2umapkjk4sehtczvl6jg63evdddwkv4r65z8g933uv0lamtyzmp4xz"
+validator = "tnam1q89xnpnrfsefr9ynj4v8ngdu35me8xudzgn94afm"
+amount = "1"
+
+[bond.signatures]
+tpknam1qprnz2umapkjk4sehtczvl6jg63evdddwkv4r65z8g933uv0lamtyzmp4xz = "signam1qzptfjc27aal8vzkf5vudd4la7l38h0l0lx0vrm2r2cdyljxqce3gdcr96c607f0t6tdj8qj3wqjgt5spak9pjf70l9rq57c8h3lg8qxp4cchq"
+
+[[bond]]
+source = "tpknam1qzg049xrm8ag7gwwskj9xydgn6s7faq38mwkz04kpu2q0mh9pcfljvfsu7t"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "100"
+
+[bond.signatures]
+tpknam1qzg049xrm8ag7gwwskj9xydgn6s7faq38mwkz04kpu2q0mh9pcfljvfsu7t = "signam1qpq900hec5yz6nhus4ycm2fpckx6p2wt98s2fy2gsf22rq5ax0z3haa9lqzl0mhz46dfj356zvy2k8e72g6fnw5d67zfuflz4dtu0xg8jtg8r6"
+
+[[bond]]
+source = "tpknam1qqvznxrhsaan7usamscl48n4v9vw5lcsmvdqax0xwvmc2z0xccdhw53v0vj"
+validator = "tnam1q8ev9tdg3v9hgm3y4muy7xy7tnmd9ne8ngctj9th"
+amount = "100"
+
+[bond.signatures]
+tpknam1qqvznxrhsaan7usamscl48n4v9vw5lcsmvdqax0xwvmc2z0xccdhw53v0vj = "signam1qprrctly9lk08t9rlp886wu503td4f6fgnqg96dm7hjdq4afngg6qqal4282dqqqlfq38k98ye6tv9hrvvz02uhxzh54nwzrx7ccwvcvw8pgl2"
+
+[[bond]]
+source = "tpknam1qrypvf77c4nxz6v6sqcwlwhegn09p9hef5e2rsgfu4jwgw533fqn2jtjqte"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "101"
+
+[bond.signatures]
+tpknam1qrypvf77c4nxz6v6sqcwlwhegn09p9hef5e2rsgfu4jwgw533fqn2jtjqte = "signam1qznzc29ssuey3udnzmy8qsfany4tp3yd2w46tau9nd0qghjnc5wru5vy0dy32pl67wj8452qj5agpr8tq8wx3wemgdtd43yj500ftjqflsc2z4"
+
+[[bond]]
+source = "tpknam1qqx0lextje3mqnxx32h4jeejz0jj8j63jqyxh65utm5k4sh23sehzqp9xgn"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "50"
+
+[bond.signatures]
+tpknam1qqx0lextje3mqnxx32h4jeejz0jj8j63jqyxh65utm5k4sh23sehzqp9xgn = "signam1qpxqn5y4qd54ax9rxt5lv943eqjsn5fhxncdy40vz806c7jsgslj8vcw7tm9pcmnhc55wj8yhh8yh2edmc4n7m5r9qp9qh2yv2d5cqgyvgut40"
+
+[[bond]]
+source = "tpknam1qqkry7ltgvldaxr5hen4h7k9mxeqxqp8r5t4q8jlw23l0z4f7sl3x25de7l"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "23"
+
+[bond.signatures]
+tpknam1qqkry7ltgvldaxr5hen4h7k9mxeqxqp8r5t4q8jlw23l0z4f7sl3x25de7l = "signam1qzsv4eh9rntrlzlnfytuflg4l30vk53mngxmqlk42usq349r67ptu4x38qvf6vxz25sgn9yurdwx5a8dsxll8uepdr9493clkvs8lwcdv4rtuj"
+
+[[bond]]
+source = "tpknam1qqzzdteyrpexc9v5v05ytq04kcl2z68fv4h39xh4r8ch5my35lwlcrdhqq8"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "2.8"
+
+[bond.signatures]
+tpknam1qqzzdteyrpexc9v5v05ytq04kcl2z68fv4h39xh4r8ch5my35lwlcrdhqq8 = "signam1qpgl5wxt69hzv9m840gcmjsr29avva5s3zc0q0uk88wm9s7v9fg3ysgs3peyd4c2avnrjw0p9tcvaneqds2wt97m0l03y57c9azntfgyda9huc"
+
+[[bond]]
+source = "tpknam1qzxcyt7cknnr20d90hurm3nn2m94h6rt2lutu7hzpx0zevtcxx3ms4e32mf"
+validator = "tnam1qxzwta6uhcsv40a8l4g5t07q0ey50c9dlyt3s272"
+amount = "250"
+
+[bond.signatures]
+tpknam1qzxcyt7cknnr20d90hurm3nn2m94h6rt2lutu7hzpx0zevtcxx3ms4e32mf = "signam1qpnlqqyf8437h4dsdae4lv46hknc85ckdmcfu6g4lwrew5mae250m56cz9m9z0s3f4sqqe0wpv77rqafw7gd6nhxsj0hd6l7yqedsgs9tszwaj"
+
+[[bond]]
+source = "tpknam1qq5gn654g7kum8kqsdcdplkrjuulq9hd2zs8plyqc0phwpn39kyzztpeqmn"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1234"
+
+[bond.signatures]
+tpknam1qq5gn654g7kum8kqsdcdplkrjuulq9hd2zs8plyqc0phwpn39kyzztpeqmn = "signam1qqwg3s8xlu2k69w5j6yk9zwn02yyxarsltfly6zr2jpz3y7upfhy9e4ujsr59r3tasrryxlue0tq6alrpurtk4f0jm90f3m660fnqvcy68p2y4"
+
+[[bond]]
+source = "tpknam1qptt4hcgpqx8lxsvhll5gg8l6x2c72tx6swj2gtkaceppxeresfp6ruy6w6"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "150"
+
+[bond.signatures]
+tpknam1qptt4hcgpqx8lxsvhll5gg8l6x2c72tx6swj2gtkaceppxeresfp6ruy6w6 = "signam1qzcy8tx28zy9mq7vuy7lcd27z7rf2m3jrlefll4p2py04x9un3sdmkrrcukvyswguesq22856l86j3jpfpqtvtdsaszrgwtf0t2eu4cfqvww66"
+
+[[bond]]
+source = "tpknam1qza0qfddngc0jzenvckjycl54fjl5k8hx0s0gecrl9hcxu9g8ntxvvnetpc"
+validator = "tnam1q8qt5qy99fvuhltq3pg20k223crauw6phulv0kfj"
+amount = "212"
+
+[bond.signatures]
+tpknam1qza0qfddngc0jzenvckjycl54fjl5k8hx0s0gecrl9hcxu9g8ntxvvnetpc = "signam1qrs7gt84lkem4g9qy02y63lplhzly46aza8lnhm6623pt96jxmq2f9m55k9v43lv5szlxujc8w7h0jeredkxf27f3x6c5nj0u89ldpswk3uske"
+
+[[bond]]
+source = "tpknam1qp2gtmzahffgrhgla460qmy75uqmpjl23ymup2aup3e202c2nxp2clax5x9"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1132"
+
+[bond.signatures]
+tpknam1qp2gtmzahffgrhgla460qmy75uqmpjl23ymup2aup3e202c2nxp2clax5x9 = "signam1qr43kwlt5yg9jwryzx4ku4s9e4ksda45hgfgswtd2g6u0vwqt9ylmd3z3fx8k9ln553vvz5wqvepwd5wf646srh9mqsyf4re56nlgtcw0t4tf4"
+
+[[bond]]
+source = "tpknam1qpwedxkrkrwv0cwf024ysuzemkg0w33stdj30kt4rmeuvn64xharqwu7t72"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "106"
+
+[bond.signatures]
+tpknam1qpwedxkrkrwv0cwf024ysuzemkg0w33stdj30kt4rmeuvn64xharqwu7t72 = "signam1qr0kugfduhuatan0adhlvshqpp53j98q4798wen0qug5u72r7zyfq86wqq0a0jjayufeujzhkpzvxzge7fxzl3vssgg6fmf95a3xkfqx2zw9uh"
+
+[[bond]]
+source = "tpknam1qpkqglf737uvk3cpna9va4jr8uhxwe65pj9zgkdssupl6futu7z7qwhscs2"
+validator = "tnam1qyawfu5rjgvhezcx0hrj6dkd0g9p97ldlvvtqvwt"
+amount = "100"
+
+[bond.signatures]
+tpknam1qpkqglf737uvk3cpna9va4jr8uhxwe65pj9zgkdssupl6futu7z7qwhscs2 = "signam1qrvgj45y7xre2tgxrgrqa2vu7dtpxj98qd0m0cnqcf4kw3rmfanvxlkfdh70hvpkx2n5e2duhfa7yl57dg2yejdeta6ttdz8sa924rspddmmmv"
+
+[[bond]]
+source = "tpknam1qq53yv3qesfahprtkeffcn5jegzjxj05c5jruelu0aem7gh27km0v6pckf9"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "6400"
+
+[bond.signatures]
+tpknam1qq53yv3qesfahprtkeffcn5jegzjxj05c5jruelu0aem7gh27km0v6pckf9 = "signam1qpegzxwr40w9necsx4245aem5q9t5w7t39u46svgjl27v2m4hj9d2rdqxkvylqs6v594n9tefy2vml7ztpr42ad8z5zwz6k86utrtkcpzu45qf"
+
+[[bond]]
+source = "tpknam1qze7yhfvc8226p70amw0ccnlzyslrsvgmqqtzxwrqx094s5akcd6wtcczfl"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "2000"
+
+[bond.signatures]
+tpknam1qze7yhfvc8226p70amw0ccnlzyslrsvgmqqtzxwrqx094s5akcd6wtcczfl = "signam1qzn8u0pvk8npln6zzz3n2shvdc2xkgvfeje2yvnqhtysyydxk2tgfenuf0trynfrxw2wg9qlaxre0e5v6kcse98mrwnp6vq5lspnm6sdenfqja"
+
+[[bond]]
+source = "tpknam1qq3c5m079as9dfd84ppflx49v77l4ytw4r3dwmrhe8lmgzf7mkrtwetylzh"
+validator = "tnam1q83z54q574kvzfujk5dt9kpy42a4zpassueswgyq"
+amount = "1"
+
+[bond.signatures]
+tpknam1qq3c5m079as9dfd84ppflx49v77l4ytw4r3dwmrhe8lmgzf7mkrtwetylzh = "signam1qr7zs5yvzd9ecqhqeg7tckgqrk2y0r632u8r545y62l23sd8xw355xjsaa8ge8v0wk0z7qan63qrtklh6y9855t8eudsn3ku6ss8q3q842xqxy"
+
+[[bond]]
+source = "tpknam1qq8vh9rc3q0kgra6lnhy5zzamzz4z2uxwtsau4gg0gzepfqwu6pqx82485d"
+validator = "tnam1q88jgxj5qhmcwxgn9frngrd30207awvdjgkwn674"
+amount = "1000"
+
+[bond.signatures]
+tpknam1qq8vh9rc3q0kgra6lnhy5zzamzz4z2uxwtsau4gg0gzepfqwu6pqx82485d = "signam1qp3vgqctwrgw5gqtdetwnz882ddw56dtzf7s0ux2dxs8vj867t6j6t4hdmak9cxfl8akuhd885navac4xslrzp42hulmh4czpfy6trcp40h8nl"
+
+[[bond]]
+source = "tpknam1qq6582ramdx76ztzx3e0eh7ppf36lx7jp42gpa2f7l6mj2ewmt4a78wtnx9"
+validator = "tnam1qxr8n7u36jcf82d0ccp0flshpwhz3d3xjv5ryn44"
+amount = "1144"
+
+[bond.signatures]
+tpknam1qq6582ramdx76ztzx3e0eh7ppf36lx7jp42gpa2f7l6mj2ewmt4a78wtnx9 = "signam1qrm3j7ms8edj5z945ytl42ahd5n2ym0xx2lu7j5xkdeyxtum60dkx7t9ylemuz0uzcg4awk3vkk2yuc2ysgtpw8grkpf4rkdmn6yvucfp930m3"
+
+[[bond]]
+source = "tpknam1qzrn6ga528m703agys9a2c4sdw6jd60lpp4qdz8mue5pz76s6efzq0q9zyu"
+validator = "tnam1q93th4stcuxfs0h8kn9uw0uhdj59dfa5hu768v4t"
+amount = "5120"
+
+[bond.signatures]
+tpknam1qzrn6ga528m703agys9a2c4sdw6jd60lpp4qdz8mue5pz76s6efzq0q9zyu = "signam1qqhl9vxsaupfcdhx85pn69jvm74uxhvmemtj5zkz7kv7tcackw5katf86nzdhwyryue7vtlmyuxk42c6yppkcvjn28mnng2vy2h38rcf4aas57"
+
+[[bond]]
+source = "tpknam1qzrn6ga528m703agys9a2c4sdw6jd60lpp4qdz8mue5pz76s6efzq0q9zyu"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1280"
+
+[bond.signatures]
+tpknam1qzrn6ga528m703agys9a2c4sdw6jd60lpp4qdz8mue5pz76s6efzq0q9zyu = "signam1qrrvnkrj2jh25cqzl8yj2tp5fnlgurg40zya5xq8kjdr7j2aap6n86z2erxn77dg2guh92mm3xy7d37x993g5vuk2t2zcwnllynd0ugvjycmuc"
+
+[[bond]]
+source = "tpknam1qp05ardxhw3zehl0znrqemz885hxmkap8uz24ypdflz6y50v9zfpkr9v4q7"
+validator = "tnam1q9sdarpylwxd5vv3e8u6wstrpz052jhls5g4a3wg"
+amount = "80"
+
+[bond.signatures]
+tpknam1qp05ardxhw3zehl0znrqemz885hxmkap8uz24ypdflz6y50v9zfpkr9v4q7 = "signam1qqpzm9xsanlgp6aw68dv792htmkytc0dgrrxxm38f3cu784ptayjc0p579362aecyr2j6mpa2tg7yk03peu8eanz5dqs38dwxd4uq7q8t5pd5p"
+
+[[bond]]
+source = "tpknam1qp05ardxhw3zehl0znrqemz885hxmkap8uz24ypdflz6y50v9zfpkr9v4q7"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qp05ardxhw3zehl0znrqemz885hxmkap8uz24ypdflz6y50v9zfpkr9v4q7 = "signam1qz5nqqg4favsy4v56pf735lh7e4n459c5p3xlxr75z3seqqm5nxf2xp07nnl758mdax0srle35rpkmyuyxggvrx7wn5ru87hhakqz3q09el83y"
+
+[[bond]]
+source = "tpknam1qryxvghqdl8dk4ufr4z5e06f4rfwqmme2xnx2l65cpukul4je2ejzkl6gl8"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "415"
+
+[bond.signatures]
+tpknam1qryxvghqdl8dk4ufr4z5e06f4rfwqmme2xnx2l65cpukul4je2ejzkl6gl8 = "signam1qqs35rk48xfdg7mpy6j3ttzae3wulsxdf0hejtmqt727m48rqj6v2dvjhf62rv8d988nunn850vq4wqh62ukl85prlferkhpu32e98cwj6ehur"
+
+[[bond]]
+source = "tpknam1qr8ag43m2wt4g9lvgqkfx7pvp5fk5n3vqs6297ejjrud0d9034sx2l0n3uy"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "140"
+
+[bond.signatures]
+tpknam1qr8ag43m2wt4g9lvgqkfx7pvp5fk5n3vqs6297ejjrud0d9034sx2l0n3uy = "signam1qqrx6azqqcgpr4g6hnd6wt5lute2js8lln63mc4tlhplxa7295v7926fzd9ahgex9y24nhef3xq9f0r9ea5jqg9387ewgcwfmeset8g8fjnw3y"
+
+[[bond]]
+source = "tpknam1qpnp5czmfremh2cm467nr99gfm7xxzjzhc68skjvtyxygvzt7z8s6ratw5a"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "250"
+
+[bond.signatures]
+tpknam1qpnp5czmfremh2cm467nr99gfm7xxzjzhc68skjvtyxygvzt7z8s6ratw5a = "signam1qr2jheheusvqw5jmwfa5lyjwdl727fmphdskavzauuegragd7a733wzj076y2ynflhhxccvrn8vf4h2v69s5wzcdcq62pzwnv4vz0gsre3ghhc"
+
+[[bond]]
+source = "tpknam1qzc6u423g6wjajf3kl30taqvhnmlap4l74wk7tqqx6c2qyw232l7g7tjgda"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "142"
+
+[bond.signatures]
+tpknam1qzc6u423g6wjajf3kl30taqvhnmlap4l74wk7tqqx6c2qyw232l7g7tjgda = "signam1qztlsjn6fzf05v4rxxnsjfjr80gkftzxwusn4l4u5mg36cu4q0wsdukq0w5tsmd89mdj02srqrjuseg6fs9fuapkpkc3h2dv7f4vnhgpjpd7dc"
+
+[[bond]]
+source = "tpknam1qqr2m2et8d8tasyd46e9v9lrq5h2tg6hfusu7e2jsdam6nmden4pk980wxe"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1200"
+
+[bond.signatures]
+tpknam1qqr2m2et8d8tasyd46e9v9lrq5h2tg6hfusu7e2jsdam6nmden4pk980wxe = "signam1qzsgcnpsh4j8heqsnd9lnhell0vlaw2tfvzqfxsegu89v9d9ct728v9g6m982m4xzf5kwqydnvldmdfahdvr52a36es3e9uahqw6j3qdqzxrs5"
+
+[[bond]]
+source = "tpknam1qp3mvtq87rnvzw23m45g7wz80y68f45s4muv9mj83n7wmmjx36dyv7cn8r0"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "10"
+
+[bond.signatures]
+tpknam1qp3mvtq87rnvzw23m45g7wz80y68f45s4muv9mj83n7wmmjx36dyv7cn8r0 = "signam1qpv4kuemnd9zlj0pz296geklm4vsvdwxfu4p74wlap4qv6fa6r9ydlz4whsjfk4tnjp8wefda7p57pttsznjm3lw57kasnk874y6hrq2swhmfe"
+
+[[bond]]
+source = "tpknam1qr6jvn22aanpws4eafs5jxh9n39070tzt86kjuync5y8xfh8v98jqv59gt0"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1250"
+
+[bond.signatures]
+tpknam1qr6jvn22aanpws4eafs5jxh9n39070tzt86kjuync5y8xfh8v98jqv59gt0 = "signam1qqcw739ke9mlm459gm5r687t2jmxzk4x8nxncc04xry3msygtxusrk70r0vpup7flydekxuhtd8xq7cwp4l6xa495v2pqse0j2yrgvqz5pt4f2"
+
+[[bond]]
+source = "tpknam1qzha2qv0hnvh3mkn9qc35qk5yg5vk6yrm3jndzp8naf2g05xtg5yujur23d"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "1000"
+
+[bond.signatures]
+tpknam1qzha2qv0hnvh3mkn9qc35qk5yg5vk6yrm3jndzp8naf2g05xtg5yujur23d = "signam1qrv3jszv2l5sfyu4jxgje6kw2qpqxfdjxuvuwnafpplw5eanxmx2q83rlqz8w03uehzmfhyvlrm4yychv4agh8255fzuy9djgfwrdmqyspxwvk"
+
+[[bond]]
+source = "tpknam1qpkjx4rt0vx8yxlg0fmfpzcslkqzdrl4jx04h0a8jamlu43al4w5cesx8n5"
+validator = "tnam1q8sjkutd5kqwcc555wr77p9fjn66nuuqfuzzc3yc"
+amount = "80"
+
+[bond.signatures]
+tpknam1qpkjx4rt0vx8yxlg0fmfpzcslkqzdrl4jx04h0a8jamlu43al4w5cesx8n5 = "signam1qzumvdyc4t20tf6wcnlffvjuve8a36udcyhy60ky8wywdzhfdz6g9egz398nqx8eh2pwrntcyqgufw3yyu4qj66gu48xxwsqjvez5gswz5j450"
+
+[[bond]]
+source = "tpknam1qpkjx4rt0vx8yxlg0fmfpzcslkqzdrl4jx04h0a8jamlu43al4w5cesx8n5"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qpkjx4rt0vx8yxlg0fmfpzcslkqzdrl4jx04h0a8jamlu43al4w5cesx8n5 = "signam1qrdcgny4qfhaqjmdpycs87p50j9sz0h04c7guwae60dfrfn9pr7tvh8ru734w0mp8hkgyra4qz2093q6ecum8t4758ygp3k3ww74xugdepdjnr"
+
+[[bond]]
+source = "tpknam1qp82c3zw3n0le4jgqjmjjsyl7gsum0kj7wrwhxuhg5vawvlw4e42xnyncep"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "100"
+
+[bond.signatures]
+tpknam1qp82c3zw3n0le4jgqjmjjsyl7gsum0kj7wrwhxuhg5vawvlw4e42xnyncep = "signam1qp62lf3f63z92j4xu2wczm3z32ftv6qqfea7qf8awl5dymu3eyvkaem8v82grt9dcnqzdzmjahmwxvg8kapr3z9zr5fwtkn4juyzvhsrzjvudk"
+
+[[bond]]
+source = "tpknam1qq2l9x6rshwacfsa04tdpem5u58ss9ph0rg0lmtk60mmg4krehvg6c6av76"
+validator = "tnam1q8sjkutd5kqwcc555wr77p9fjn66nuuqfuzzc3yc"
+amount = "1"
+
+[bond.signatures]
+tpknam1qq2l9x6rshwacfsa04tdpem5u58ss9ph0rg0lmtk60mmg4krehvg6c6av76 = "signam1qrfrthk4xncwa6m7k8x8hx96wlf97a7amm5gjyv0mg2vu6ygvu60vcegx8jnf0ju38hlszvq0mrwl0z5ny9q28awfccu0rgq6ytsg9sw3e9jjj"
+
+[[bond]]
+source = "tpknam1qz7xg4fpurcpc0867jdu6ne8r388x9yj5mhhj6mg3mqk2cj7tntxutjgnjh"
+validator = "tnam1q9pt4hukg0ga362jq2slhg4tuf692zqqngzzz54k"
+amount = "1246"
+
+[bond.signatures]
+tpknam1qz7xg4fpurcpc0867jdu6ne8r388x9yj5mhhj6mg3mqk2cj7tntxutjgnjh = "signam1qqjzc07qz8zrsc557xdpzps9zpryqwy6gyn4ajq5jy2qh6uxxumu40m3ff4n60grejh7wephmh3p7e8nqsz6actts4veqeajwmm4ujq0jrsplm"
+
+[[bond]]
+source = "tpknam1qrgeplnm6u5tg7dd07xxyjumqjffcl59lexf4zdej79jplk93ndcvy4nt8v"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "61.54"
+
+[bond.signatures]
+tpknam1qrgeplnm6u5tg7dd07xxyjumqjffcl59lexf4zdej79jplk93ndcvy4nt8v = "signam1qpexlc3x2666uqyheaz4lf3aaael69d4kstvjflud823eu8tyznf58cuur7shdfsvmr5ksfae3she0zjgfdc2scdn3e5pus22uv375gqyu006r"
+
+[[bond]]
+source = "tpknam1qzswps4l96l5zqhcysk52m22qr4h6ze2sjvhff2lj4c2hn0e56ggyx963ut"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "100"
+
+[bond.signatures]
+tpknam1qzswps4l96l5zqhcysk52m22qr4h6ze2sjvhff2lj4c2hn0e56ggyx963ut = "signam1qzkpfhpldu0euna274j92q2nxtqmj0980axcwkc6f0qk2z0fxz753cyt9lh50evmsp3ymlry4m6kz260yudcdsnvlk900tl0wayt8tqdugd9eh"
+
+[[bond]]
+source = "tpknam1qz6w43n64722fclzsckhjenx75v7d7farhl5fdr7w3h23ed6kap8kucrr57"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "100"
+
+[bond.signatures]
+tpknam1qz6w43n64722fclzsckhjenx75v7d7farhl5fdr7w3h23ed6kap8kucrr57 = "signam1qrx3ue5h85fpzywhwphs5f7rs2nzdvkwy0tkrez0v6yr453kxy2du73xyf5tahnpmkuzp8ug2tj7jv968wz8hrk5ggnjkujac6zkkfsfjgf2z7"
+
+[[bond]]
+source = "tpknam1qq6htjvkw25pcmgpfrnckj372nlplfxpj0w3l3rgwuyuvq43usgx7tuq6kg"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "100"
+
+[bond.signatures]
+tpknam1qq6htjvkw25pcmgpfrnckj372nlplfxpj0w3l3rgwuyuvq43usgx7tuq6kg = "signam1qz0s3yqqv2xkr4305fqjhskx45a8rz50wz6kmy27m06umjs5kwn6lygktfqwdfct36rqw973yq0x8emjss74vhfwy03nrjmzz7r5pkqf5w8n74"
+
+[[bond]]
+source = "tpknam1qqm9tg8vh3mzdalq59j2q29p9cjaxe74cttz5ycphda3ucl8hgjx7nkapyx"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "1024"
+
+[bond.signatures]
+tpknam1qqm9tg8vh3mzdalq59j2q29p9cjaxe74cttz5ycphda3ucl8hgjx7nkapyx = "signam1qpaeqfrh8m8zrpnnrdv8nk0d9ffnn0zs272g72u2gq3ze359aqzsr950mcme9vtjx46puwmhkn7kchzjryaj76h345arf05q0tc79lstzs4qyr"
+
+[[bond]]
+source = "tpknam1qphdvk8vn8jehgdns8dvt0x9r324mxhheypxkmkr3m2yt88snfaex0mk5sq"
+validator = "tnam1qygz4sn400y9g90rt5jx6ja0wrcx3y7u0c0ue6dq"
+amount = "170"
+
+[bond.signatures]
+tpknam1qphdvk8vn8jehgdns8dvt0x9r324mxhheypxkmkr3m2yt88snfaex0mk5sq = "signam1qqkc76qe7vlrfya7mmd87yhazrsrj68sa7h3ht0wr0rs84r245dc3x3pem5zp2tesyn6yfkawe6uqkch358andapaghnnzzsf8r4qqqf96qqds"
+
+[[bond]]
+source = "tpknam1qphdvk8vn8jehgdns8dvt0x9r324mxhheypxkmkr3m2yt88snfaex0mk5sq"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "42"
+
+[bond.signatures]
+tpknam1qphdvk8vn8jehgdns8dvt0x9r324mxhheypxkmkr3m2yt88snfaex0mk5sq = "signam1qqjyuaz9chvd7dqfsd5xsqx855rlz89a48u9gvf3a6a5q7j0546v4jw5dt2kv2zvh0rltl55k55cstt3df08zex58wjx9cayeyuft5c90x6r69"
+
+[[bond]]
+source = "tpknam1qp2s4ms38egr9u3gamwr6s89c6rh32regfehjtlfmeygu7vq903fqepzq9t"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "6400"
+
+[bond.signatures]
+tpknam1qp2s4ms38egr9u3gamwr6s89c6rh32regfehjtlfmeygu7vq903fqepzq9t = "signam1qq3lwkx8d8fdj32npr8wugqftj4av80vryq0f4du60kn88s6vn2kgaj6h6dy306zaa3wlruqltngt47hr2efsljymvz83vlwpwcnngsx8gjv8v"
+
+[[bond]]
+source = "tpknam1qzqmnr05l9hja3qnttrvhkuzrj4529ers4cnepmjggcj8gsq72dssc47y99"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "1000"
+
+[bond.signatures]
+tpknam1qzqmnr05l9hja3qnttrvhkuzrj4529ers4cnepmjggcj8gsq72dssc47y99 = "signam1qp9xn5n5duztpk4wttlhs5ewm5sw3c9ygh8akg5l529nnlw59kqe0fc7gqkqjuuypd4suvhjf8drs48p3mq6dg2g0wptj83v5le7g6cxuah0ee"
+
+[[bond]]
+source = "tpknam1qqxgd638f0efxzzx3lpk6m73kf4k80stlhdm6z2gymxzh3zk6g54u6enxjf"
+validator = "tnam1q8xasrt0q8qrkqj5s9r9xw3ee0gx5mqwyukhe699"
+amount = "100"
+
+[bond.signatures]
+tpknam1qqxgd638f0efxzzx3lpk6m73kf4k80stlhdm6z2gymxzh3zk6g54u6enxjf = "signam1qqx74fnt7ghq9g483pejtz627rqw27y49zu6fmkmdaxy4tcss4yxng2s6p5g9jwyv3hghvsv8tlvc3q9l0vwc8hphgl2vs9qdkyqlmsvpzwanv"
+
+[[bond]]
+source = "tpknam1qpgyfxhnqzp2pdh6s73nfxp5z9304lpt0wd4kacpvlt03sy3p73mvrx5phr"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "230"
+
+[bond.signatures]
+tpknam1qpgyfxhnqzp2pdh6s73nfxp5z9304lpt0wd4kacpvlt03sy3p73mvrx5phr = "signam1qz3gt2ldmkwup3qcjarjrpdwtqhyecs0p8ntwrjx9pe9gv6exxaccrz59au80g2vh654qzarh9v4wh2dax7yatdxvzt9vjm6c6ypdactg6j3hl"
+
+[[bond]]
+source = "tpknam1qr02alqa8m79czmv5yh4xs4kk07p6pltfxrrl3n5m0dkuwvxnfetzvw28zc"
+validator = "tnam1q8rrg8slcx6c8z0zq4tdkmtpq6ljmcytxgd3wktz"
+amount = "100"
+
+[bond.signatures]
+tpknam1qr02alqa8m79czmv5yh4xs4kk07p6pltfxrrl3n5m0dkuwvxnfetzvw28zc = "signam1qznwsuhwwf9vfkfme7qd7l0tl9tdcp5wu3w4w9xl9xcmsfqw6qe45z4csss8nc74n849mtfcpzmrtlnhyf5xtgdcp2qjmy9fty8taugrmtdncd"
+
+[[bond]]
+source = "tpknam1qrrtz3w3jn6t77zpfhd9cchd0cf09cqj2pana4rdkdqv0e3664lhxvv5e4g"
+validator = "tnam1qy7fms2m4kpx5khvp4x7r3pr8e4xdqghpsrsd0pn"
+amount = "2500"
+
+[bond.signatures]
+tpknam1qrrtz3w3jn6t77zpfhd9cchd0cf09cqj2pana4rdkdqv0e3664lhxvv5e4g = "signam1qz97vjvf3n5rnw4cltqdf356csdwjp8d3a74gss0av94xrvsqaurre5tgnzsyysedw90jv2cwfr7f8ydqzh0sn7qnd8l3glkxh0c9kqyraxlnt"
+
+[[bond]]
+source = "tpknam1qq09vdmrt2ry5lxste0l9wyqawdehg6jrlfxz6gqygsr0thkwr57xk86yye"
+validator = "tnam1q88jgxj5qhmcwxgn9frngrd30207awvdjgkwn674"
+amount = "100"
+
+[bond.signatures]
+tpknam1qq09vdmrt2ry5lxste0l9wyqawdehg6jrlfxz6gqygsr0thkwr57xk86yye = "signam1qp4yekfjcvrq5vhfjtsfgy3jel7xhj9rydfq4xxrj84ha0759cp49l4uxsn55c223qgl3rjwzze6zwpaxv75wdpv2efwlvdec0nhdxqqrze30w"
+
+[[bond]]
+source = "tpknam1qre3xxyqjfe4p2xycgjteqg3lzqvn7x0r8s9pqaq5zzz73yr0xv8zrjnlyg"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "100"
+
+[bond.signatures]
+tpknam1qre3xxyqjfe4p2xycgjteqg3lzqvn7x0r8s9pqaq5zzz73yr0xv8zrjnlyg = "signam1qzp5twdz7klxkgdk8ruremwkz3gz99nrafd6h7rfgupq0ne50gyg3m2e7xue8eu9265uaw88djqmcgwrjevlts5yc9tvqyehzs74luc2lc3cpp"
+
+[[bond]]
+source = "tpknam1qqrck2vnfhj9tqwwjs063mauz7kaajvdnnrd22lpfyhncc3ldsxnvtypqxu"
+validator = "tnam1q9sdarpylwxd5vv3e8u6wstrpz052jhls5g4a3wg"
+amount = "120"
+
+[bond.signatures]
+tpknam1qqrck2vnfhj9tqwwjs063mauz7kaajvdnnrd22lpfyhncc3ldsxnvtypqxu = "signam1qpc9kvve6yn46gqvaukp0tv89v5cxlczzc7cdld5keuzmnvluszn6n4z0e5p564ysv7zvtczwj9x8j2zuk6w75n2uc9smk0gdstqg9c9qrard0"
+
+[[bond]]
+source = "tpknam1qqrck2vnfhj9tqwwjs063mauz7kaajvdnnrd22lpfyhncc3ldsxnvtypqxu"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "29"
+
+[bond.signatures]
+tpknam1qqrck2vnfhj9tqwwjs063mauz7kaajvdnnrd22lpfyhncc3ldsxnvtypqxu = "signam1qzqffz60ev8p5qcc3apw4q8xkxfz3s7g2229dmhywr4nuz8zg6ycufajh0jkdyeprc22kauepvct4m2lvy95wrvx6vs04dqc4vptx3gyrv5y2k"
+
+[[bond]]
+source = "tpknam1qqg586vvw766zr8raummrfd5aawg766v9752rzkhhvd28wwagq74wpnru87"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "101"
+
+[bond.signatures]
+tpknam1qqg586vvw766zr8raummrfd5aawg766v9752rzkhhvd28wwagq74wpnru87 = "signam1qp74kxaqt5z0jgva87k9mwaf5ls9px0ufwkm2vtq3f6tj663ewqdy4ketw9u5t70lk3y7yv5dym6eyxt8d406qdv4k4v5nyuhmlnunstp48sw5"
+
+[[bond]]
+source = "tpknam1qqjd87nnhkkl2mpq8v4rej2ekn4pfqn50s7440s46suue2nv4zw7y43xg3n"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "0.1"
+
+[bond.signatures]
+tpknam1qqjd87nnhkkl2mpq8v4rej2ekn4pfqn50s7440s46suue2nv4zw7y43xg3n = "signam1qqgfclhgjp4x83cv74t0mmnakzgs6gtvs402d76wyk503wgj84ynckcndl2ve6jteept7hgxx0k9cuw5k2gzcpm6sy7n5mlkm3gh4ysdlwua5s"
+
+[[bond]]
+source = "tpknam1qrt0r8v7hguputkqunwdxge0dgjn383kg5rm3xsakac7dk97axg4gqqmtwh"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1255"
+
+[bond.signatures]
+tpknam1qrt0r8v7hguputkqunwdxge0dgjn383kg5rm3xsakac7dk97axg4gqqmtwh = "signam1qr9dmras8phearycazthxc42xpr7kg5msmn9d7thx5zy83vqyvjvqxs0vtw7w8a7xwq6kuf87mh3yhlhklnpc8rd7c36qppk68jmm0s044qlja"
+
+[[bond]]
+source = "tpknam1qztpx4kq7y80xxw9ytfwny6ux9d4jkrws7s33yan8u7w6lng64urqmxux0z"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "120"
+
+[bond.signatures]
+tpknam1qztpx4kq7y80xxw9ytfwny6ux9d4jkrws7s33yan8u7w6lng64urqmxux0z = "signam1qq77a5msl2kh9dc2vzzvynalvu20l45v4xvdkelyp0wy9eq504gj9tt59qh2ewh739r4u02kzdk5djg0g3uct0hdfsvjxth9pgdyjggtm6ptcv"
+
+[[bond]]
+source = "tpknam1qztpx4kq7y80xxw9ytfwny6ux9d4jkrws7s33yan8u7w6lng64urqmxux0z"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "29"
+
+[bond.signatures]
+tpknam1qztpx4kq7y80xxw9ytfwny6ux9d4jkrws7s33yan8u7w6lng64urqmxux0z = "signam1qp29sxs9ph8fefl9ka8tn94ctnlxn6ndle29mw679kpuevf3e38waqfjduayd7r0she0qyjhghlfuemlwzc8cxsua7hseftxdrd3l8s84fm9y2"
+
+[[bond]]
+source = "tpknam1qzsmnlfdhqjxljajj3l7jp3kkpmj6w6dhxy0w5leyvhd2j46t95q2szu3v2"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "149"
+
+[bond.signatures]
+tpknam1qzsmnlfdhqjxljajj3l7jp3kkpmj6w6dhxy0w5leyvhd2j46t95q2szu3v2 = "signam1qrlap6j7jx0a3xs2f84ave88m39eucw6hvs0g433u9fut00d3cm3090pa7e9lk04vnewn0ckmf8jnlmdm0555zvu33x40uy2tgtzcrc2ahphcg"
+
+[[bond]]
+source = "tpknam1qr5nde2yk3eceuye42vz6q3mydgx040utq59yawzjj66v3y0s2c5ct267g8"
+validator = "tnam1qygz4sn400y9g90rt5jx6ja0wrcx3y7u0c0ue6dq"
+amount = "120"
+
+[bond.signatures]
+tpknam1qr5nde2yk3eceuye42vz6q3mydgx040utq59yawzjj66v3y0s2c5ct267g8 = "signam1qzgee65uwd3dd5fwrxtt00kpdenp4y44egaqmvc2097xjf7w0lv5ukeguyddmdzl35ew3vy46yrka7zxl90ttm4q9e3hmy2tycexlrcru0c87k"
+
+[[bond]]
+source = "tpknam1qr5nde2yk3eceuye42vz6q3mydgx040utq59yawzjj66v3y0s2c5ct267g8"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "29"
+
+[bond.signatures]
+tpknam1qr5nde2yk3eceuye42vz6q3mydgx040utq59yawzjj66v3y0s2c5ct267g8 = "signam1qphzy5u97460dtsuzh9h65u5fthhasxlty0wwynxm5rgdc6dgkaehh4stdgtvc6uspjvwg89cylrr4qdg4nkhc8nzdww9u30rhy8hxgpgpqtj0"
+
+[[bond]]
+source = "tpknam1qrr75w9qdu93mcg07c3zjkcvqrgrmx8lhresq5myrca05mwg7k6l7tsx8kf"
+validator = "tnam1q9sdarpylwxd5vv3e8u6wstrpz052jhls5g4a3wg"
+amount = "170"
+
+[bond.signatures]
+tpknam1qrr75w9qdu93mcg07c3zjkcvqrgrmx8lhresq5myrca05mwg7k6l7tsx8kf = "signam1qp6cpza6gsph4wjt4atsljqnacm33hqe5f00u2f96v40te7wcyk4sperwp7pnzs6t8f9h5m37p59zcpkaj5req4v7gpyetrpm2myuyqgldvzsx"
+
+[[bond]]
+source = "tpknam1qrr75w9qdu93mcg07c3zjkcvqrgrmx8lhresq5myrca05mwg7k6l7tsx8kf"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "42"
+
+[bond.signatures]
+tpknam1qrr75w9qdu93mcg07c3zjkcvqrgrmx8lhresq5myrca05mwg7k6l7tsx8kf = "signam1qrz8dyxvwgw4h3yx536ly4cm8zz9pawfgjefzjecmj3wj4ns7cah5337gn4ph5ptvu7g8c598ulaspqzkrcqc6faqxq7su3zk25ye5cptfv735"
+
+[[bond]]
+source = "tpknam1qr6lkesrka8d7dyjg9lqdzra0lw6d5m6npf9jutzsm5qwxeeq48kspmu7px"
+validator = "tnam1qygz4sn400y9g90rt5jx6ja0wrcx3y7u0c0ue6dq"
+amount = "120"
+
+[bond.signatures]
+tpknam1qr6lkesrka8d7dyjg9lqdzra0lw6d5m6npf9jutzsm5qwxeeq48kspmu7px = "signam1qpw42jpkzg79hcm5rq4vggknpcw6cngdqzxqg07h6stlf9hqe05a49wdzrm0wll65ssmm90x2lj5rx2qukyn24dnctc4c8kaymy5kjsfxjrhad"
+
+[[bond]]
+source = "tpknam1qr6lkesrka8d7dyjg9lqdzra0lw6d5m6npf9jutzsm5qwxeeq48kspmu7px"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "29"
+
+[bond.signatures]
+tpknam1qr6lkesrka8d7dyjg9lqdzra0lw6d5m6npf9jutzsm5qwxeeq48kspmu7px = "signam1qraskfmndgdnmh8wzek3mq0hzhnnqkrd8875mgv0w4hj6mf3e4yzvkfsserqj2uvltr0f97nvzc4v7rfjamfuzu0n7ezn9pqd54gd2cphyyz90"
+
+[[bond]]
+source = "tpknam1qz95klmxtcxc8gt50dh8lyena5hpjl4k5wfnvrqffc33dfte73ezxeefzaa"
+validator = "tnam1q8sjkutd5kqwcc555wr77p9fjn66nuuqfuzzc3yc"
+amount = "17900"
+
+[bond.signatures]
+tpknam1qz95klmxtcxc8gt50dh8lyena5hpjl4k5wfnvrqffc33dfte73ezxeefzaa = "signam1qqque3k5ll4rukgqx4f7wju3su655g57d9rsd4jzeer7jt0d5hzetc8d93afy8fdsllcwu43en3wgxmg53d9afp8y82gpmqzems43xg2wp5laq"
+
+[[bond]]
+source = "tpknam1qztyftfe22mhdeu7qhfraeul4nzthvxj63vursp7pp92utqcl864ulw5hs5"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1"
+
+[bond.signatures]
+tpknam1qztyftfe22mhdeu7qhfraeul4nzthvxj63vursp7pp92utqcl864ulw5hs5 = "signam1qpjshaz32wmxqweauwjp4tchlvd4rdv9xejwnxr3zsl5qqqkyk9k8096ekk97jt2ta7wdy3jc20t5rygy88nmqm8yn58fe7umwgq35c2pkd9s5"
+
+[[bond]]
+source = "tpknam1qrjsfr7wan47yqxcuv3twjs42lp0ww0a0s28utdvds93939rf9nls5vajnh"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "100"
+
+[bond.signatures]
+tpknam1qrjsfr7wan47yqxcuv3twjs42lp0ww0a0s28utdvds93939rf9nls5vajnh = "signam1qrpe25myxrup5a9kekhn4gny0tx06f4nylja34w0ndl0rs5dugmfl9yvz40tthkhgnc6x2hcamu4uurzu897yr0g6gjzy283c4ay8hgvz6uw8s"
+
+[[bond]]
+source = "tpknam1qp49egh9uzp346gftnqfhdp740g4x2d3yz0r6a0gkhwedcf6e7jnjv60pvt"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "242.8"
+
+[bond.signatures]
+tpknam1qp49egh9uzp346gftnqfhdp740g4x2d3yz0r6a0gkhwedcf6e7jnjv60pvt = "signam1qz3w05ph57tf5catn6f7vlhq7djm99fy5ewqay9ndn4jlfnlgrrfh093gvfn588lqgdq0v8yuzcrpvp0jyfyzzsj88t5sazmfamme7cvs6w074"
+
+[[bond]]
+source = "tpknam1qptjxulgshmc5qv8lpx7thde5m76pl8y0d6dd452s0x5v9z40u7q6qaxx3q"
+validator = "tnam1q9pt4hukg0ga362jq2slhg4tuf692zqqngzzz54k"
+amount = "80"
+
+[bond.signatures]
+tpknam1qptjxulgshmc5qv8lpx7thde5m76pl8y0d6dd452s0x5v9z40u7q6qaxx3q = "signam1qpmdnwrqj7hw24hswm0hv50ct434savmtghklkwakjwau9gyg9z6z9vktllywwes8nruzpse2k6wf9c7f5g95tylhx94l422ctswqqsrlp93ym"
+
+[[bond]]
+source = "tpknam1qptjxulgshmc5qv8lpx7thde5m76pl8y0d6dd452s0x5v9z40u7q6qaxx3q"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qptjxulgshmc5qv8lpx7thde5m76pl8y0d6dd452s0x5v9z40u7q6qaxx3q = "signam1qrn2rnty0tu6vxdmxw5uvksd39te73vxxkhgmwx0dntwdr8p55haepcr9dxe6604z7ryjswppxscx370m907v9rg00kzn24qjf33c0cxtx3532"
+
+[[bond]]
+source = "tpknam1qz95rwvs2qqvq7cesmtveafau4rdqmtespqg5xdlrzj8c5a64cg5u3wj3zw"
+validator = "tnam1qx304q35wkfd5zd07rgapwsrmg3tsapncsqdcg25"
+amount = "80"
+
+[bond.signatures]
+tpknam1qz95rwvs2qqvq7cesmtveafau4rdqmtespqg5xdlrzj8c5a64cg5u3wj3zw = "signam1qrv2gm70t2dkt4w2qm0pmu87e7nxz3ts93glk86e48qa9n3grjj6a9yts7jurm56gz397g65ucnx6e85whwre7k964ckrkvktyyw8aqq5avu0c"
+
+[[bond]]
+source = "tpknam1qz95rwvs2qqvq7cesmtveafau4rdqmtespqg5xdlrzj8c5a64cg5u3wj3zw"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qz95rwvs2qqvq7cesmtveafau4rdqmtespqg5xdlrzj8c5a64cg5u3wj3zw = "signam1qr8yw8u4f26vgpjncveqsqp69pyjhzq8qnhz64rd3vrdsue3dvkmj5g8rwkm263mgap9jafqn9nxyy494a6675dsc0peap3j5kat56cpx3ymvv"
+
+[[bond]]
+source = "tpknam1qr62wvwump3th4m67rawz3a2fqwyzn9wewa0rnyvxm367y7ewftzjyylmqd"
+validator = "tnam1q8azt2cpqmc6tr2gvg5v62e4jr0t9327yupaf595"
+amount = "80"
+
+[bond.signatures]
+tpknam1qr62wvwump3th4m67rawz3a2fqwyzn9wewa0rnyvxm367y7ewftzjyylmqd = "signam1qzc0l0a59fnv20sljelj499a92n9g9anvf6rjjs5hnme3awrgv7l4wuk3m6940kss25puh7mpkv78988d94tvanwgjllfhkmcv9vqesq5xptak"
+
+[[bond]]
+source = "tpknam1qr62wvwump3th4m67rawz3a2fqwyzn9wewa0rnyvxm367y7ewftzjyylmqd"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qr62wvwump3th4m67rawz3a2fqwyzn9wewa0rnyvxm367y7ewftzjyylmqd = "signam1qzae406fq3c9hdjecmuxvnjmvq2s3j7935a9v8raf5tpyzqu7xw3um33dh8fuzsf8za33kvg20qjr6v4zm63xlx7uey7sshr3kppljcx6nd0ew"
+
+[[bond]]
+source = "tpknam1qpjjvr70fvvjy8d2ynwu9077drlesy6w3k6vxqagtgdrgvkpwpxk6q0a7qr"
+validator = "tnam1qy6y8ws67ks2p5jl53s6yukre554mhwrugdp8vjh"
+amount = "80"
+
+[bond.signatures]
+tpknam1qpjjvr70fvvjy8d2ynwu9077drlesy6w3k6vxqagtgdrgvkpwpxk6q0a7qr = "signam1qzkrqtskmdl7j80px4yp9tn27sjfxtf9nxxu9yhkwe9tmpxqp7h2mcy3yg0ymd9ypmywng6fg6smnksl6lr7cgrpuhjapvm6yp5q4fcp2jn8ea"
+
+[[bond]]
+source = "tpknam1qpjjvr70fvvjy8d2ynwu9077drlesy6w3k6vxqagtgdrgvkpwpxk6q0a7qr"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qpjjvr70fvvjy8d2ynwu9077drlesy6w3k6vxqagtgdrgvkpwpxk6q0a7qr = "signam1qrh27zvnnjrpgxyf8uyxj9qx6c900y0j30ej9ly7nhez05crhs7l5na6rvzjuh2078cfdp8hvhdw2w9t0nzuwp8dce0pruy04xad6wgqjuyg9w"
+
+[[bond]]
+source = "tpknam1qzqpflem99p6yg0e95n8l6c64qejlftcvxewg3kva0uvqsu640s4k4zmzlz"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "10000"
+
+[bond.signatures]
+tpknam1qzqpflem99p6yg0e95n8l6c64qejlftcvxewg3kva0uvqsu640s4k4zmzlz = "signam1qpl8neahkch3lxycrgnh5dyy7hcdmhpl68flq3zxrwkn3fh9k66m5nse7xr5dg5pxs7xzw3l2dfznw2u7qje6j8m9ffwakc998nc3pqrc2d93h"
+
+[[bond]]
+source = "tpknam1qpfwjg3p07x7kqkmhfhcsv3gp536969zcfq4e8kftm4dktdsklg3j2ucnc8"
+validator = "tnam1qyd33xrjdpr3hwhy0ckut7lk56gd5gjflgtul8hs"
+amount = "106.8"
+
+[bond.signatures]
+tpknam1qpfwjg3p07x7kqkmhfhcsv3gp536969zcfq4e8kftm4dktdsklg3j2ucnc8 = "signam1qrkj64fq0uehnnuhlk9ffalng99fm2ffh85jj4nuvazd66ukq0pqlz89khw4rjky2ey4az2azv09f4ka777z6e7k6nwzga6sz0vwjfcggw4xwr"
+
+[[bond]]
+source = "tpknam1qrdtq84nnd0d0tzw32d0sxqajrnz06hm4wkus0cruffktp5nkvwuq3sy6jx"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "300"
+
+[bond.signatures]
+tpknam1qrdtq84nnd0d0tzw32d0sxqajrnz06hm4wkus0cruffktp5nkvwuq3sy6jx = "signam1qq4yh3nesu6f45ygvf550vrhp9jchptaqr5w3cvgp58u8ckavnhm0s6866vqtumu4d9xndr93yg3ye0cc2ernre0aa55nzy2spqcf0cw2yk2ly"
+
+[[bond]]
+source = "tpknam1qra4nmj52tsamjktv8mq4sd7kmjlmc6lhuc6v0q89jtnnt792n98cq2s350"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "80"
+
+[bond.signatures]
+tpknam1qra4nmj52tsamjktv8mq4sd7kmjlmc6lhuc6v0q89jtnnt792n98cq2s350 = "signam1qplzrp0mrwvc05ay72gf7vcw088qfg9my8rd2mtv76u42mzl8qzu3qyckh0vf4kw6u5phc4spets0slsp3y6hky2e7sp6g5ppalmszqw782q0q"
+
+[[bond]]
+source = "tpknam1qra4nmj52tsamjktv8mq4sd7kmjlmc6lhuc6v0q89jtnnt792n98cq2s350"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qra4nmj52tsamjktv8mq4sd7kmjlmc6lhuc6v0q89jtnnt792n98cq2s350 = "signam1qzdx9cnx2qcdaxze8e4fn92dlvqg7n64qm0y4r2hjaf3q4tnvcjrzlh78t37902262d9kqlyyz6rvxtg9gelxkeurt7rwd0qhyjhsdqyw72hc7"
+
+[[bond]]
+source = "tpknam1qz9lxzhxgq2n6c9mjv8ung73fg5n27sly0jqscqh5lnps8uhx6jhqvnu5p7"
+validator = "tnam1q89xnpnrfsefr9ynj4v8ngdu35me8xudzgn94afm"
+amount = "80"
+
+[bond.signatures]
+tpknam1qz9lxzhxgq2n6c9mjv8ung73fg5n27sly0jqscqh5lnps8uhx6jhqvnu5p7 = "signam1qpqw0zuxz50x5npwk90ut0gnswltc54jlcwlmdadmnhk883j6dfr3aml3tda24clgduer0y94dcgzwvuu6vtv0h3l60wdmhe66mptfsg2n4r34"
+
+[[bond]]
+source = "tpknam1qz9lxzhxgq2n6c9mjv8ung73fg5n27sly0jqscqh5lnps8uhx6jhqvnu5p7"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qz9lxzhxgq2n6c9mjv8ung73fg5n27sly0jqscqh5lnps8uhx6jhqvnu5p7 = "signam1qq7guy9vghwec0v3zjaqqk9gfg90ynsh7s5gql28l3lgyl6f89s8pd0kpr8xu57dz344j9sd9dsar4l9n3npy2wsall7ewjkhpnjs2qgn8e4s7"
+
+[[bond]]
+source = "tpknam1qptqs6s8una99nkpzwhg3vkgglmardq5qq90ezvme7j9kg0jrxsszzflma2"
+validator = "tnam1q9rq7p4wzy6fea96xs5sr8qnsxsfdr2zugfsvw2n"
+amount = "80"
+
+[bond.signatures]
+tpknam1qptqs6s8una99nkpzwhg3vkgglmardq5qq90ezvme7j9kg0jrxsszzflma2 = "signam1qqxuq5vw00x8ch8l3tfyc3szqcj2xn8uj0867phjkn24pha7m3wg33h4888q2h3ptmwpxdw74quxwkv0xtndvdtd4clfhw0chs75pkcpzr9zd2"
+
+[[bond]]
+source = "tpknam1qptqs6s8una99nkpzwhg3vkgglmardq5qq90ezvme7j9kg0jrxsszzflma2"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qptqs6s8una99nkpzwhg3vkgglmardq5qq90ezvme7j9kg0jrxsszzflma2 = "signam1qrrwwuvauna2llqnmz8spzef6l2dk76glvtx6akhjxp336ntrtxfxekxcclu33j9k84v48rwmv8v2kaz5vpjam4h280h89u3zegk9lgtlv8u82"
+
+[[bond]]
+source = "tpknam1qqjtxjdp60rqtd06uy2rddnrsqf39ldjxygk3cjsnnkld0n23j7d6latln2"
+validator = "tnam1q9pt4hukg0ga362jq2slhg4tuf692zqqngzzz54k"
+amount = "130"
+
+[bond.signatures]
+tpknam1qqjtxjdp60rqtd06uy2rddnrsqf39ldjxygk3cjsnnkld0n23j7d6latln2 = "signam1qz4644k2tyvdhks3hsq3dszrg7r7ggpev90ht7cjjwwhytvh4u93yhkvyu8pp4r4u426kfrlr5502t26gkz7qfa87hrlxu00v62ymacxng8tf0"
+
+[[bond]]
+source = "tpknam1qz09mhcgke80er4xwpxzmqht8y8wlam7y6k7turn2e222046cy0ak9ufhmr"
+validator = "tnam1q9skz9pj8rac6tnjkcahqw7q68tg5ekgmsxurann"
+amount = "400"
+
+[bond.signatures]
+tpknam1qz09mhcgke80er4xwpxzmqht8y8wlam7y6k7turn2e222046cy0ak9ufhmr = "signam1qpqt54xvdpzvqx2cfnalcpwvkk6gcaju85lskcq3kac6984gd3vuxsf8ydpsw5ppjlm9twrga2nulx5zcfpp5yyyfephfz7nevxk82svmvf9nh"
+
+[[bond]]
+source = "tpknam1qqf8y7tgvkt9he3dyfjqd9ufghh6f9gm9navf63tf6e3mwczm024usmaact"
+validator = "tnam1q89xnpnrfsefr9ynj4v8ngdu35me8xudzgn94afm"
+amount = "480"
+
+[bond.signatures]
+tpknam1qqf8y7tgvkt9he3dyfjqd9ufghh6f9gm9navf63tf6e3mwczm024usmaact = "signam1qqs26u9fjtcrasflpjfn9l32z2u9e0avaa695xfdyaaatvz6dmndrdtk44075dxr3usur37pc2ghn57p5yqj8wznchmwwce3832calswx85qed"
+
+[[bond]]
+source = "tpknam1qqf8y7tgvkt9he3dyfjqd9ufghh6f9gm9navf63tf6e3mwczm024usmaact"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "120"
+
+[bond.signatures]
+tpknam1qqf8y7tgvkt9he3dyfjqd9ufghh6f9gm9navf63tf6e3mwczm024usmaact = "signam1qqlmfgau6ge2xdp2f0rynqetlrhxdu9s7mw83xtn9santzn3s6m72pdjpzs9l35zn38sse5wjmmgkm7xm3xswnlzazdaxs8gttju0ccqggqc8h"
+
+[[bond]]
+source = "tpknam1qq47dt5797gfz90uumamqq5f7da0xmme0refqq05mrd6t7h3wmknj9074d6"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "102"
+
+[bond.signatures]
+tpknam1qq47dt5797gfz90uumamqq5f7da0xmme0refqq05mrd6t7h3wmknj9074d6 = "signam1qpdwlsfu49z5sthdghupmc5r7hezfjant5fn9uka5d5y7vmslhtymwauhzvat4yhwzps9cu5n97r7y66ptgq2wv89he5esuzcj6054czt705n3"
+
+[[bond]]
+source = "tpknam1qq65wlk0f8tvx4xpyp9kfr66ulvr6a2g5y3vs3hyns5nge8ate386hrmgln"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "140"
+
+[bond.signatures]
+tpknam1qq65wlk0f8tvx4xpyp9kfr66ulvr6a2g5y3vs3hyns5nge8ate386hrmgln = "signam1qp9r8e78gmz6uc4jhmqgjzqeyv5wq7c2udk9k4ng05rmjlggpuzxkndg3dv3luhv70hlwd7nt6wss60qqwvfllydnrtr8e0aglx3dgsrnauctq"
+
+[[bond]]
+source = "tpknam1qqc9kynv8chszp5t3f83y8fvn66xv6tw0jzvh94dxcak7mr7nan263rkael"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "105"
+
+[bond.signatures]
+tpknam1qqc9kynv8chszp5t3f83y8fvn66xv6tw0jzvh94dxcak7mr7nan263rkael = "signam1qrpw2mleeqrydy04a8g4duvf4q8ks96r8v8hrgzcjzdx3nrzc8n9uy65l4watmsjw4pzq7y97sklg786a2kucxhzf6uaajsczk6lmkctxjddj8"
+
+[[bond]]
+source = "tpknam1qzxqkpg276m5y93vn7dptse00h6umadnmfd3zvndjv5w40xwa830k3zxw2c"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1000"
+
+[bond.signatures]
+tpknam1qzxqkpg276m5y93vn7dptse00h6umadnmfd3zvndjv5w40xwa830k3zxw2c = "signam1qp2kgx20p5mkry9ec3x9vvsz47zlpufhwsujxhtentfdpef4y677rx2xa0lrcy04pntvtx2lxz2zz08jru3hq4dgrv549gkuunjhkpq8xtl0qg"
+
+[[bond]]
+source = "tpknam1qzpy8jczsklfj9fysd3c6letcpc8cz3748a9ppnvavmq79pxf36u2hq90ll"
+validator = "tnam1q9vrp45qtphed4q2vc382qrtf2gfykf50vssfe2h"
+amount = "135.82"
+
+[bond.signatures]
+tpknam1qzpy8jczsklfj9fysd3c6letcpc8cz3748a9ppnvavmq79pxf36u2hq90ll = "signam1qznqpejc6qtx7lf05lzr5nzm5q4eg699h8e4qf5wjte0x5aqtc5gn9qv0ll7n8h36fvarl4mhxm60hcjzdpg8r7eehyq77lsmd6fh9q2wz2vt8"
+
+[[bond]]
+source = "tpknam1qzk0qn6lp9hp9y7q6zaqfksh0urxv37up6thue6hmzulg0lw55aakkulfae"
+validator = "tnam1qyxd5eh0mf49at77dursxnlsygn5se6d45tj5y47"
+amount = "200"
+
+[bond.signatures]
+tpknam1qzk0qn6lp9hp9y7q6zaqfksh0urxv37up6thue6hmzulg0lw55aakkulfae = "signam1qzfa82vguyrjfxed36dmcz9gtpapfwljcpkwdyj673duzglwv2xv2nz7m3ccdpy6lxmlurrwsnsl0p8fxm0jmss5fvvh4nzhtfzp2vq95pjec4"
+
+[[bond]]
+source = "tpknam1qqetsdlngpq7upmh50ydfenjykrtuaqv4n962n0y0u8q88w56635xfenmyt"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1250"
+
+[bond.signatures]
+tpknam1qqetsdlngpq7upmh50ydfenjykrtuaqv4n962n0y0u8q88w56635xfenmyt = "signam1qqfhen7s8tuq3hf5jprnju37gu5zfnnxq0afvsayyvkwvv56vlswh55ah7trumxh8pezcd36u2ala6tl66k29zd9m8g0tw3qah6f6rgtm0ewch"
+
+[[bond]]
+source = "tpknam1qrng4jhs5md8djunj89qpwqcgdsyjmeezhu8hnyhzczlx75nl2jn29j0ud3"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1100"
+
+[bond.signatures]
+tpknam1qrng4jhs5md8djunj89qpwqcgdsyjmeezhu8hnyhzczlx75nl2jn29j0ud3 = "signam1qry5505dvghhw5n9tywnuygptzt82sl8l65dhndtf6zscr3wztwt0c4cpwwv3uzmn2mzd5ajkz5q2wydn8eza046vdsumra4820u8qgve6e7kv"
+
+[[bond]]
+source = "tpknam1qqx5393x69ya8x77xljwr065e354ns44hcm5ptuvnk9mps6dtuj4js55sz0"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "135"
+
+[bond.signatures]
+tpknam1qqx5393x69ya8x77xljwr065e354ns44hcm5ptuvnk9mps6dtuj4js55sz0 = "signam1qp7xep46kmjt7h5y6axzwg6hx46zptclwv2a6pstwxk2nvh77428z7zu8y936hanrc4x2p5du8jhr2wr8n60837sh6qehtl752fwvlgx9z5jne"
+
+[[bond]]
+source = "tpknam1qpjx6p093sjnde97yh4p7nsuxja7fpn0rwcvt0xx7d37ph7amg6v5hqhkr3"
+validator = "tnam1q8xasrt0q8qrkqj5s9r9xw3ee0gx5mqwyukhe699"
+amount = "700"
+
+[bond.signatures]
+tpknam1qpjx6p093sjnde97yh4p7nsuxja7fpn0rwcvt0xx7d37ph7amg6v5hqhkr3 = "signam1qq4ajkpu944n865p4k6gn4uakdc4vvkdwmapx0lr7hs7q3fl36huja5suv9c73kpetgf7skr0tcklsxtl0aj4snk6cvlxje62n28fhgg802ggx"
+
+[[bond]]
+source = "tpknam1qqw436smc4pt4m487gxk575suvnec98u0hg29qgh3qt7h45lp7qwgdcqn7r"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "106"
+
+[bond.signatures]
+tpknam1qqw436smc4pt4m487gxk575suvnec98u0hg29qgh3qt7h45lp7qwgdcqn7r = "signam1qr5uqvdlz0sk425x55nz44pwsh9yqsj0r89s9hgm0xe72fkga86zcjeh3kmz0ct453n9t0vuy47ncqy7mspff972tj0fzky747ysk0gg5k9hpk"
+
+[[bond]]
+source = "tpknam1qqdcl0qw3cwzcv7dkfqchyqujucz0030althct9qfyhcc3q78z00vt93fm2"
+validator = "tnam1q89xnpnrfsefr9ynj4v8ngdu35me8xudzgn94afm"
+amount = "100"
+
+[bond.signatures]
+tpknam1qqdcl0qw3cwzcv7dkfqchyqujucz0030althct9qfyhcc3q78z00vt93fm2 = "signam1qzlj99t75zfctacgnv0c6v04zrep7f3pjanmwsa3ytfdnr76qlrk0hysem9q3gup59vjt3gypj5mpz7rcflyyvp7fv0n8wza3g4qaug0le7caa"
+
+[[bond]]
+source = "tpknam1qqqp3dsfsr8ex84ruxp3aet7rqja3p4ktxwp3juv4rq02vztpd4c50gfdtw"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "10"
+
+[bond.signatures]
+tpknam1qqqp3dsfsr8ex84ruxp3aet7rqja3p4ktxwp3juv4rq02vztpd4c50gfdtw = "signam1qrpks4d9wev4x4c5h0w0p9t2cqmz829k205qfx3nwtu47zqsq8yfzh5dp5wxwjm6rsd8m725yaf8e0ava4g88w0l2sqcnjdfzqj8tyqpz450lp"
+
+[[bond]]
+source = "tpknam1qpwv7m5fh72zrkj3zp3n8mh3uazcqev7y4pswfkssw37gskvwp0aghylj7e"
+validator = "tnam1qy93z8ek2wwm3l3nd9gl872n2argnjfrwstywpmj"
+amount = "1261.5"
+
+[bond.signatures]
+tpknam1qpwv7m5fh72zrkj3zp3n8mh3uazcqev7y4pswfkssw37gskvwp0aghylj7e = "signam1qpne8eqryfm28d22vkntfxhf4c03gqktsdd7u0kvwngp7ua0ksa0hvsyx4p8nttvhjvae08mzexc9hs85rwhf96qjm3uqu8j5fatpjgw9dskes"
+
+[[bond]]
+source = "tpknam1qqtalujsysxd5hfaddwz74tnfvd3ew2rysnavhy9rupvxk64wwwv66tdcqx"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1000"
+
+[bond.signatures]
+tpknam1qqtalujsysxd5hfaddwz74tnfvd3ew2rysnavhy9rupvxk64wwwv66tdcqx = "signam1qq34mlune0lwctnvcpm07npv0v7f9fhyv4lrnva4feyvq9wwmzkgd3mqh0pug7awa22hhuldzv6mmgyad8048gdzjgnu64rcxkmusaqzrq49sf"
+
+[[bond]]
+source = "tpknam1qq4fnp4083sju9x9u5yv34h4a0r8sfmhqygd5tdt0q4hyuecswqdcys6lf7"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "106"
+
+[bond.signatures]
+tpknam1qq4fnp4083sju9x9u5yv34h4a0r8sfmhqygd5tdt0q4hyuecswqdcys6lf7 = "signam1qzll5mj4ntmn08efex2374uewfz3rw0h65nx3p6p5c7t655gp5d0lvsdxl5c42z87ryf33tznged5w0c0x7arp2jl07z5tntrp4ar9gpycs7yy"
+
+[[bond]]
+source = "tpknam1qq4r9999egaj5ack7tvazvxhvz467qsqvd7zv395rsy8szmymgj5x9hnm8h"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "135"
+
+[bond.signatures]
+tpknam1qq4r9999egaj5ack7tvazvxhvz467qsqvd7zv395rsy8szmymgj5x9hnm8h = "signam1qpm6jzuew9g43tyukt5gpl4mf3e5s0uswzh2q0pxtff3vtku6936qddetnaxr9n56xyjy80e8nvzcan34nryu9ermgdh3y0z5z658dqppkdr5j"
+
+[[bond]]
+source = "tpknam1qzxl5trk2u585zm86y4mp2pxepr8qxxmk9376cks9wmamnm25mwhzmt0vmp"
+validator = "tnam1qyd33xrjdpr3hwhy0ckut7lk56gd5gjflgtul8hs"
+amount = "1000"
+
+[bond.signatures]
+tpknam1qzxl5trk2u585zm86y4mp2pxepr8qxxmk9376cks9wmamnm25mwhzmt0vmp = "signam1qpqm50ml0zlccqmpce9d9s8mzvpf969qkry0kxcl3whjfuzh2x6dq87pg55v2n35spv7lfsen0rj0wkluw4n3fel8jfyp2wj6qq6yyg0q8h6yj"
+
+[[bond]]
+source = "tpknam1qzn39wh6wx02sz7rfwjx355x7wxh9sxx5nk5tam7q0x792nlddl45lsurju"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "106"
+
+[bond.signatures]
+tpknam1qzn39wh6wx02sz7rfwjx355x7wxh9sxx5nk5tam7q0x792nlddl45lsurju = "signam1qp9ymd30a42qjnfzha07z6rk0vy7kk0f02hnqyl0x54hu4e4kd0fgl787usgch4klpl0agmnuthzpnc7thrqlfgkhhwr0eeu82dfk7qphd7z5v"
+
+[[bond]]
+source = "tpknam1qpruasf2efe7x830sqh6nxh46n6madxcznezn9d9t9zvw5u2sxz55e0zy7c"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "6"
+
+[bond.signatures]
+tpknam1qpruasf2efe7x830sqh6nxh46n6madxcznezn9d9t9zvw5u2sxz55e0zy7c = "signam1qq79dcccshctsdedlzyl87m0p08mauvqfyn6ptkuuejcvf7sckupfm8fgyl7npf57ftgcpld90t8emva0xu32xmrwthjar8ll0k7hssta6h2cr"
+
+[[bond]]
+source = "tpknam1qppcucg6q25um4amt5wvh9qj3p2phxzfwrphmw3acn9zpjk8gug07mxv2ph"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "100"
+
+[bond.signatures]
+tpknam1qppcucg6q25um4amt5wvh9qj3p2phxzfwrphmw3acn9zpjk8gug07mxv2ph = "signam1qq6gealaf5r25lmwvynhqzt9vscfxz2fuky5c24qp49pmdg3sf6xsgq7y07c5k4enpztk3mtzm7000u8876qf2ex6dwcxrfrpduxegcpq7826g"
+
+[[bond]]
+source = "tpknam1qryemg6w200qeu2gszsqw2edr8semuxs2umwd6zrxh87xlge45xfw2q25r4"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "450"
+
+[bond.signatures]
+tpknam1qryemg6w200qeu2gszsqw2edr8semuxs2umwd6zrxh87xlge45xfw2q25r4 = "signam1qz639j6hn0hujvnc4tkl3lz2ws62eyey3du4q9nv2u5sj9pyrkj86lev3ucrrp4zm90y93mseh5s44dew9j0rkcuexxeml9wdxe6wegxd46sn3"
+
+[[bond]]
+source = "tpknam1qz5j86squzdn936vwpa0c2mvl2tuaxpkvzjqg85x5ehce78z2eff7fua9m7"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "60"
+
+[bond.signatures]
+tpknam1qz5j86squzdn936vwpa0c2mvl2tuaxpkvzjqg85x5ehce78z2eff7fua9m7 = "signam1qp47ak6sdknsxv72yzpx0pyuuypupnvswuu3hs24wngh0m3dryxf8dykgl5vayrmky69ng7zk6mzaetv3eqq49cwtsf0aley30ku9tg9pxphu0"
+
+[[bond]]
+source = "tpknam1qqzvnp3xpsu7rkx8lsanr46077vwdwvgke3aytvcadhhwkuy578vg9wjzk3"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "140"
+
+[bond.signatures]
+tpknam1qqzvnp3xpsu7rkx8lsanr46077vwdwvgke3aytvcadhhwkuy578vg9wjzk3 = "signam1qqltqw06zqkyqkaf9uyy59uhw6sf8yu02jvramcxsqewrrl4wmf0dfkw469yy6rq6s6hqx4ed7u7gatztv472yc6p5k0lgd8fg6nwxgwdhhfm8"
+
+[[bond]]
+source = "tpknam1qrrx37uepnzkkmc8vyenxqe9cd0kkz64znupzmkmd7r0eghrxr3f7ey2e3k"
+validator = "tnam1qxzwta6uhcsv40a8l4g5t07q0ey50c9dlyt3s272"
+amount = "736"
+
+[bond.signatures]
+tpknam1qrrx37uepnzkkmc8vyenxqe9cd0kkz64znupzmkmd7r0eghrxr3f7ey2e3k = "signam1qqxjkaxh7z4pp9gm75jqavr0r95udyj0pgxjwvrggn2ydqp5c8tnkxzjvzlvchja9zzzd2w7acge6xpcujg33lc3r83m06kfg660l5qrpdxl3l"
+
+[[bond]]
+source = "tpknam1qqzsf9ujty3qthl8zfr7skwl2mllna77tan7rtc8h8gx77d4lqnusapxwg4"
+validator = "tnam1q8xasrt0q8qrkqj5s9r9xw3ee0gx5mqwyukhe699"
+amount = "800"
+
+[bond.signatures]
+tpknam1qqzsf9ujty3qthl8zfr7skwl2mllna77tan7rtc8h8gx77d4lqnusapxwg4 = "signam1qraclkvfyky4nv6y9an5pk7nuaf5xpss6j547wrq7m5rcq2ejvjdjxszsaphwqstnu75vy2zeyzjpmc3x88gzjvs4zl87pyvja2j4ygy0jxwtd"
+
+[[bond]]
+source = "tpknam1qq5pyev6ahtztwtl3dx098farfdnn37na27dszkqx2x0jpuleqa4ghh20hy"
+validator = "tnam1q8xasrt0q8qrkqj5s9r9xw3ee0gx5mqwyukhe699"
+amount = "4"
+
+[bond.signatures]
+tpknam1qq5pyev6ahtztwtl3dx098farfdnn37na27dszkqx2x0jpuleqa4ghh20hy = "signam1qp9xqss3rf2f4y732922jmu229c0tj2a4f26a3a8wd2x7lug222ky8z5xgqzy9kyxnjhc0lhmg2kslqzuyksmg9hjxpvusfwpyyyzzcpz2m4d7"
+
+[[bond]]
+source = "tpknam1qq5pyev6ahtztwtl3dx098farfdnn37na27dszkqx2x0jpuleqa4ghh20hy"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1"
+
+[bond.signatures]
+tpknam1qq5pyev6ahtztwtl3dx098farfdnn37na27dszkqx2x0jpuleqa4ghh20hy = "signam1qzylx3k2hnwutg5n6fv58r43cvcyz9hru7tvf2cuk3msxvktpjxp4s4jjjknnrx6nqcywz2kra4sm9h3nezdxzc2yxwa3pqul6fvjeqxnc87nl"
+
+[[bond]]
+source = "tpknam1qr06lkgfs7069j2haec7a8ze4xnydhs42r23ykfp2n877msws0cduu3v29a"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "106.88"
+
+[bond.signatures]
+tpknam1qr06lkgfs7069j2haec7a8ze4xnydhs42r23ykfp2n877msws0cduu3v29a = "signam1qqyunxkd40kmktsprpdxxnnmvhh9cktur8szhhnspzm6j4sq0hmtrmvqjaxf3hjs98m6acur7ck97h3tzm0s394lyuf65akxp0v7ptgrsfuvr2"
+
+[[bond]]
+source = "tpknam1qqeud6ncwe6hw9jddn2dj7xkcryaws08hkgahgjj03ejh65c9uxhx8vusj5"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "100"
+
+[bond.signatures]
+tpknam1qqeud6ncwe6hw9jddn2dj7xkcryaws08hkgahgjj03ejh65c9uxhx8vusj5 = "signam1qrwcemsvyd8sh3zfmq2pnrsahvqyqnzpygsvu3ahuk9sca50p0nqtdwnrsx80fmezy3t8d66mr0ff9ss0u5nv5hl3ycmdvztxcxad9qzrlapa7"
+
+[[bond]]
+source = "tpknam1qrz6cd7qk5e2hz8ke55wy3dqlpe0mukrrs6etl342cvep5de2z0mvq33fz2"
+validator = "tnam1q89xnpnrfsefr9ynj4v8ngdu35me8xudzgn94afm"
+amount = "650"
+
+[bond.signatures]
+tpknam1qrz6cd7qk5e2hz8ke55wy3dqlpe0mukrrs6etl342cvep5de2z0mvq33fz2 = "signam1qpzd8qardmcx63639dmwt7z7a76rvm39qshwymp73rfj0pyzytkjs9x87ttv3w3j3mdlkvaw886ur84jc9u6jl844h7kkyzw4g7dq5sv6gjsl3"
+
+[[bond]]
+source = "tpknam1qqa28tq8up7kjyj55jsylzz38p5f5ad69k6fjmss7szv4nepzvt32h8nnf4"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "70"
+
+[bond.signatures]
+tpknam1qqa28tq8up7kjyj55jsylzz38p5f5ad69k6fjmss7szv4nepzvt32h8nnf4 = "signam1qryy2uplel74dhjndcta8z0m097w6ydfdf9cxmn72xm38885ymxt7mcdun8pk85cnupzcc9yc4j58a80eg9ct5m7jnm8zge6fv9ed3sw68kk0m"
+
+[[bond]]
+source = "tpknam1qqeu2wng3pvgz6058stkgaq8ld3n8a36m5s5z7y4wge0ufryymj6c549efz"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "103"
+
+[bond.signatures]
+tpknam1qqeu2wng3pvgz6058stkgaq8ld3n8a36m5s5z7y4wge0ufryymj6c549efz = "signam1qzxzjr9hcf2xnmv9jxfwajmsh7mtvdvk86utpa2rgsvklrar5zgplw4l77lcvznjd3t8t3zrpv5szr65wvdhusxeac9n3d59eyrkz8cfg40ylt"
+
+[[bond]]
+source = "tpknam1qq5clu3pqxl88xxnpxd3f673ledrrsv6fyfzcp3pj7s6qk5dhlmpvm9a464"
+validator = "tnam1qxzwta6uhcsv40a8l4g5t07q0ey50c9dlyt3s272"
+amount = "108"
+
+[bond.signatures]
+tpknam1qq5clu3pqxl88xxnpxd3f673ledrrsv6fyfzcp3pj7s6qk5dhlmpvm9a464 = "signam1qrh8whmlqp8apwad027c98r494l0u3f825syf9y60d4nqadprh06uv700wqqnh3q7wq04rl4ftst9vg33lrmdtexv8hnag5d5h6x29qysmyze6"
+
+[[bond]]
+source = "tpknam1qq5clu3pqxl88xxnpxd3f673ledrrsv6fyfzcp3pj7s6qk5dhlmpvm9a464"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "27"
+
+[bond.signatures]
+tpknam1qq5clu3pqxl88xxnpxd3f673ledrrsv6fyfzcp3pj7s6qk5dhlmpvm9a464 = "signam1qpa6sflu27szespkmjwktvesuwg97mkdsux68r65vehrzvefk3aftmvmnkk4cym3alzghpt4cckw6ta6cjnymj8rzpvcyymjlp83d4cr8ns4hn"
+
+[[bond]]
+source = "tpknam1qz9kdmja6n0n5wuhas24ve5th9588xpl42njjfn6mt2ygytl806yu50m5hx"
+validator = "tnam1qxzwta6uhcsv40a8l4g5t07q0ey50c9dlyt3s272"
+amount = "10400"
+
+[bond.signatures]
+tpknam1qz9kdmja6n0n5wuhas24ve5th9588xpl42njjfn6mt2ygytl806yu50m5hx = "signam1qptjnjnqs5d4glavq8s9gly6jvw4en3wanhaj9dv5eyfv77r2gkjlvr8d5kfwcscsfky0s5cls0w32nf0x5mjkw6nsf22jk4xs7nf9sdp5lvlc"
+
+[[bond]]
+source = "tpknam1qz9kdmja6n0n5wuhas24ve5th9588xpl42njjfn6mt2ygytl806yu50m5hx"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "2600"
+
+[bond.signatures]
+tpknam1qz9kdmja6n0n5wuhas24ve5th9588xpl42njjfn6mt2ygytl806yu50m5hx = "signam1qr624c00rg2mvngdh224575c76vlupafhxpgs0w6n7g3mht0rpmhaszca6l9vh60gx22td05nce7h234fx4py666au4k8qux7r68macq65t8t3"
+
+[[bond]]
+source = "tpknam1qr4rzyguhfchr6qmt2skqhewglsgyuw2pjn8zmkjt6trhdd2zm3pqjkumy6"
+validator = "tnam1q9sdarpylwxd5vv3e8u6wstrpz052jhls5g4a3wg"
+amount = "49"
+
+[bond.signatures]
+tpknam1qr4rzyguhfchr6qmt2skqhewglsgyuw2pjn8zmkjt6trhdd2zm3pqjkumy6 = "signam1qzsdlq8g39dang43qm5xcfpudell9uu9alxt67j6fse7pmekmjgmj0gcem43cwzx9hyeukd243hfrl6vr0zyk4te0mauemg7lckdsdgvx8g0uj"
+
+[[bond]]
+source = "tpknam1qr4rzyguhfchr6qmt2skqhewglsgyuw2pjn8zmkjt6trhdd2zm3pqjkumy6"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "12"
+
+[bond.signatures]
+tpknam1qr4rzyguhfchr6qmt2skqhewglsgyuw2pjn8zmkjt6trhdd2zm3pqjkumy6 = "signam1qr7uuaekjjuha3e2edg2ay7fwe0vmg9kxc5fj8vunan4hye4x3ln673xks5gv09qczyu8d6njkltzsnk27903309s76y0cathz4ty7svzmvt4j"
+
+[[bond]]
+source = "tpknam1qqrmgaskh6kn3ayzpp5hs0whyszhmchmvlhne2nancqmt2nz68eh6smux8q"
+validator = "tnam1q8xasrt0q8qrkqj5s9r9xw3ee0gx5mqwyukhe699"
+amount = "150"
+
+[bond.signatures]
+tpknam1qqrmgaskh6kn3ayzpp5hs0whyszhmchmvlhne2nancqmt2nz68eh6smux8q = "signam1qpsu46hddna06mg2kq3qfstn0nd5k8ws2nr0tfes96eyqlzfwyvfqrlq84c4j47q8zszhul4npqa7qxhfhj5tnja7utlj5s20dadjdq9vhfg37"
+
+[[bond]]
+source = "tpknam1qzyyz7qmec9dgqwmmxv363a78zxa06qjz37rl8hm0kl7dyv9vcefs65jjeg"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "210"
+
+[bond.signatures]
+tpknam1qzyyz7qmec9dgqwmmxv363a78zxa06qjz37rl8hm0kl7dyv9vcefs65jjeg = "signam1qr86m7qrnjgelejd2xxkw5w8rqqzs42csgfufzh3cjh7pzrlva7lwx06hu4dc9ewvvkmtck2m7ga57zejl6lalecrajv5w0gjeqlgsstd40v47"
+
+[[bond]]
+source = "tpknam1qz6hvdntzr7sdzwr0jqkmngc8nx4wpjqshgkfv085jzvgysc0x4gkerandm"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "100"
+
+[bond.signatures]
+tpknam1qz6hvdntzr7sdzwr0jqkmngc8nx4wpjqshgkfv085jzvgysc0x4gkerandm = "signam1qzlg4zmcksr38erwssyfpav5x40evq4rf6sqdluguylhshn399xm9j2vzc6rchn8f96dw6zt4qrawp66w5869twfx2nzlddsjw30ftgpusnfna"
+
+[[bond]]
+source = "tpknam1qrdyswr3yv5uyz3kznhne3gmvt8remm25q0zvt40dx9l9rm4pz4tzcmqsxl"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "140"
+
+[bond.signatures]
+tpknam1qrdyswr3yv5uyz3kznhne3gmvt8remm25q0zvt40dx9l9rm4pz4tzcmqsxl = "signam1qz0wm5au2zwvguw3jk55fpege6ylj5hsferd5p0sqea0k0jxgg9vza5ssvn45nj3lehpuluveetmczkvd58et4ngxgu2r9xc98wlccqf53eycd"
+
+[[bond]]
+source = "tpknam1qz6g29nsej782at9v8we309qyqsw7yewu7nashtmjjatkqq9e9gcq0tp6mw"
+validator = "tnam1qxyx90jvjew6ng5tgpfgfhwrt4g4atg7kq9u7wly"
+amount = "359"
+
+[bond.signatures]
+tpknam1qz6g29nsej782at9v8we309qyqsw7yewu7nashtmjjatkqq9e9gcq0tp6mw = "signam1qqm8uafr3dkmnup4k5wgh4tpf3hy33c9uvuz0nzeyrx6mglwexj2k7j2f7gez8j2rxrwyj3fhg96r3ypv65c36c74swnvgqq67mnprsv487gqe"
+
+[[bond]]
+source = "tpknam1qq2hm0yxq27edvdtht6c5n0pwqnjgc7c6d3q6fqap3lpgwulm6tjuswahx8"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "1200"
+
+[bond.signatures]
+tpknam1qq2hm0yxq27edvdtht6c5n0pwqnjgc7c6d3q6fqap3lpgwulm6tjuswahx8 = "signam1qp3x78x36pqu0s8e3ueeqpvpnzc4jj7e79x3fvwr60epwa35sw8fflwpv3ea8zz09wnk5fvpfpcdxzwkp2p70c88mtvfn5wjk3w047qd8kjaxk"
+
+[[bond]]
+source = "tpknam1qp5lq37p89guf9wlmrdav0j0rlngp28y55ahew988vuxyvl9fu48k4c52ay"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "250"
+
+[bond.signatures]
+tpknam1qp5lq37p89guf9wlmrdav0j0rlngp28y55ahew988vuxyvl9fu48k4c52ay = "signam1qqcquypt2wfphrxep8yh48n8cl8p2lhpnf573e6ypshmh838g2gz35gdtnznq6zp3xtusmnashda6f32nnagpwzf4g4xerqfvq65c6ggajwptn"
+
+[[bond]]
+source = "tpknam1qz2dnzjj2g3tsfetp2nka7axv9njsvr5f7fh4nnyhff89hw93ha9xl940l6"
+validator = "tnam1q8yksf6xqm6u8e2axhy7wyx0elslnh7tdsrp2y9m"
+amount = "100"
+
+[bond.signatures]
+tpknam1qz2dnzjj2g3tsfetp2nka7axv9njsvr5f7fh4nnyhff89hw93ha9xl940l6 = "signam1qp3wzqf0hxusrus2efjw2gwvys2xgyrtlhmy4q7x70nxcadyaczwrfwkvp38829m6tz4zjjjjwafhqm6a89l2kyh73fmrwnt3vtu4kg28g3z4d"
+
+[[bond]]
+source = "tpknam1qpg0ef7nwyz59p469a5peg4wnxueqz8260n27ez4svufm7597cc3wghrzy0"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "350"
+
+[bond.signatures]
+tpknam1qpg0ef7nwyz59p469a5peg4wnxueqz8260n27ez4svufm7597cc3wghrzy0 = "signam1qpl6nrk7r5d9xpemfryjm5tge985tp839u7qwt8zkx0xnre5w3x8dqn2f4v84ls9hsjt8mngyrcsj7szhlw6k5z78p7swdmy2cuzkcs8dslpe7"
+
+[[bond]]
+source = "tpknam1qpj50yepaupzkyj5c6t8ldne7g9vyu5353ajf3u8wxa4mnkc77ceuj94cna"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qpj50yepaupzkyj5c6t8ldne7g9vyu5353ajf3u8wxa4mnkc77ceuj94cna = "signam1qrhw4k47epyy6ex2wm88eunwhne9zjcn0zgl5wlwj4xaud37e3ls5s5ntg3xejvxhsc4wmhwcqmzz0p2aty8073q7pwu8ljrref94lsy7jgfnw"
+
+[[bond]]
+source = "tpknam1qz0j6wdym7gkwyts6277s5xezq6z78xs62prx89njrsajecxwg4cyc4cs2q"
+validator = "tnam1q8sjkutd5kqwcc555wr77p9fjn66nuuqfuzzc3yc"
+amount = "104"
+
+[bond.signatures]
+tpknam1qz0j6wdym7gkwyts6277s5xezq6z78xs62prx89njrsajecxwg4cyc4cs2q = "signam1qz00gfv8xw5l2axs9hugux8dyt5u48hgpmnzxnjwhhrm9kw4uncxets2sqrup54y2ykn2e90z0lu6p68wfmtgdrutgupytcya3cglcqrumgljz"
+
+[[bond]]
+source = "tpknam1qp0076tamxkwladlx8p04sh8cu6ckcd629xhtdf0as3g3aje9g5z5uqjzyt"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "100"
+
+[bond.signatures]
+tpknam1qp0076tamxkwladlx8p04sh8cu6ckcd629xhtdf0as3g3aje9g5z5uqjzyt = "signam1qqz6gfrfmdlx4dyytt5u0hyz9gvt0yytv79nexrhjkv5jhagv933nntljfh7z7hjtcap4tdxd5j3zn7pu6x5qzfv543enmjaxgl9z0svvq2mrd"
+
+[[bond]]
+source = "tpknam1qp65hz3qvc5tdvpy6g42wl3lq6whlj5yrk4vn8razp6k84fnlg2hwqmy4jd"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "4000"
+
+[bond.signatures]
+tpknam1qp65hz3qvc5tdvpy6g42wl3lq6whlj5yrk4vn8razp6k84fnlg2hwqmy4jd = "signam1qz63se9n7zk5krst4f6g563vde4emrxel3wjv7jws9mlml8f90gu378xceess86p43vwcwkh0lyltm2z7wa5kxm0jjgkymzdh8j2ngqpxh9lda"
+
+[[bond]]
+source = "tpknam1qpz2yzdnhef702vrsxunxq6p8qk03y5nejgtvqww8whv7zunxvfrz9cmtpe"
+validator = "tnam1qyd33xrjdpr3hwhy0ckut7lk56gd5gjflgtul8hs"
+amount = "86"
+
+[bond.signatures]
+tpknam1qpz2yzdnhef702vrsxunxq6p8qk03y5nejgtvqww8whv7zunxvfrz9cmtpe = "signam1qrvl2zc90zrutu0052d6265q0trygrhk0v5qnd7r7ph6dmjndehrsms799adxzqm98gmaxdkwxn0lzqe3ehaz7805qgndgp7l60qzxqd2wvnz0"
+
+[[bond]]
+source = "tpknam1qpz2yzdnhef702vrsxunxq6p8qk03y5nejgtvqww8whv7zunxvfrz9cmtpe"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20.88"
+
+[bond.signatures]
+tpknam1qpz2yzdnhef702vrsxunxq6p8qk03y5nejgtvqww8whv7zunxvfrz9cmtpe = "signam1qrjdnm47fmknerlxy65esgc7jf6d4ujeujn6nqkk9scfcxjpd2nl3swnsn6fp9m860v6rpwdtk5n7m8mz5ve9gz9ya2sylpjpq5ah4cy6h6s09"
+
+[[bond]]
+source = "tpknam1qpxzjkt5s2s2eu96squvhzwdwkeda86aeqstfykkautl2svkplsas7ceq5a"
+validator = "tnam1qyd33xrjdpr3hwhy0ckut7lk56gd5gjflgtul8hs"
+amount = "135.92"
+
+[bond.signatures]
+tpknam1qpxzjkt5s2s2eu96squvhzwdwkeda86aeqstfykkautl2svkplsas7ceq5a = "signam1qprq8h9jl9lm7cpk6j5vph0zehpjgrf3afz927g4hfxt8ycjkglektxf5j5uhy2ple45vkdyfm3ktvxlp3y7zj7kyysuu0g0dx9jymqxuy5k0f"
+
+[[bond]]
+source = "tpknam1qqrn808svtgaypfjlxcqc2knr32xzgyjd4hws84kmynvc7hzwfwes2glvp8"
+validator = "tnam1qyd33xrjdpr3hwhy0ckut7lk56gd5gjflgtul8hs"
+amount = "106.88"
+
+[bond.signatures]
+tpknam1qqrn808svtgaypfjlxcqc2knr32xzgyjd4hws84kmynvc7hzwfwes2glvp8 = "signam1qzppdyqpd3c2qa8nzgju2h5zr20dpxp56ys5axz73yap2g87mhwv5ngn4nej9fxsm0ymx6segukeeyvk8jllxe3kr7u8c4t0jrth7xsqg7k5u6"
+
+[[bond]]
+source = "tpknam1qr3js2lfqj6htvdlvujaxmhfmwmmh65wgfkt0v3nzvt66kuv54yau79vu32"
+validator = "tnam1qy6y8ws67ks2p5jl53s6yukre554mhwrugdp8vjh"
+amount = "1655"
+
+[bond.signatures]
+tpknam1qr3js2lfqj6htvdlvujaxmhfmwmmh65wgfkt0v3nzvt66kuv54yau79vu32 = "signam1qzdmjrkjh98wu47urp7whpw69stawdvrg8a7wxeme839fvtga78662m7aetz9ukj2ph7chmfjz4xrg666u3h7nvmvejaxa4zmv05x4sgvsgwpc"
+
+[[bond]]
+source = "tpknam1qrldjujx8acfv2d6g9husr4dal350a0hxu2pcc7zkfr6q5ssdcrd2cucgqe"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "100"
+
+[bond.signatures]
+tpknam1qrldjujx8acfv2d6g9husr4dal350a0hxu2pcc7zkfr6q5ssdcrd2cucgqe = "signam1qq0xxj2qzv50nzu54y4htzp9wn4cpsxugcm3vqvxlmp66hxq0lc45kvwpr23j5nrdmgkenmyqt05c9jcx66azyld8jpdg749n3l3acg9c808sp"
+
+[[bond]]
+source = "tpknam1qqk6mxkdv3amcjltkssjs7mms6g04527jg6rrph02n8h7sar0r0v2y9rc0j"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "100"
+
+[bond.signatures]
+tpknam1qqk6mxkdv3amcjltkssjs7mms6g04527jg6rrph02n8h7sar0r0v2y9rc0j = "signam1qqrz7lc6cjzyevlt8p8xnsmffc965n63en60qvw2mm3x473trnkn9n6t2w7qdfyytu7s726yh2fn6mcv7c9eqyg5lsv0mr7s0r3gr3cqu4c7x4"
+
+[[bond]]
+source = "tpknam1qpzjsumyrgxppm8taa4uw0mhesrf0m55pmrsz0w9p2q96m228xz5s035mt9"
+validator = "tnam1q9rq7p4wzy6fea96xs5sr8qnsxsfdr2zugfsvw2n"
+amount = "1000"
+
+[bond.signatures]
+tpknam1qpzjsumyrgxppm8taa4uw0mhesrf0m55pmrsz0w9p2q96m228xz5s035mt9 = "signam1qpwphvt2ydl6hslq6urseppsjgf06ndrf4d7dda0r0wrzhcnhpkd60wjz4xvaknq8c2qlge2egtd4qenj5a8ux7hwh0sqw3nvqzrtdcfcqgg62"
+
+[[bond]]
+source = "tpknam1qzaewr9wpdksvnz6tr8x3ykj2ehutnspuvwgkh5xd3cklx60ju0e5u3lt9c"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "1000"
+
+[bond.signatures]
+tpknam1qzaewr9wpdksvnz6tr8x3ykj2ehutnspuvwgkh5xd3cklx60ju0e5u3lt9c = "signam1qp3tq5qtpp6u5nlve4yg88zr7qte656uuptvlrnndcf8get555mgqzszl05pr47lxvxfs32rpw37q7ljnf8wty8sznzafvtr4723n5g8rcszg4"
+
+[[bond]]
+source = "tpknam1qrv9rr5gja9qd352hmhxlgxarm2zedkm7mveegatu6fw9gnfe72rxdpca4c"
+validator = "tnam1q8azt2cpqmc6tr2gvg5v62e4jr0t9327yupaf595"
+amount = "160"
+
+[bond.signatures]
+tpknam1qrv9rr5gja9qd352hmhxlgxarm2zedkm7mveegatu6fw9gnfe72rxdpca4c = "signam1qq6lvzkmjm3na2m0x4vjv6ztchkp56nhltkt9ze494t52k8sw3yshkpasnrwr3mxmpqgl9qket7vflkr9dhql3c24xrep3pc9gndgfsqde0spf"
+
+[[bond]]
+source = "tpknam1qrv9rr5gja9qd352hmhxlgxarm2zedkm7mveegatu6fw9gnfe72rxdpca4c"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "40"
+
+[bond.signatures]
+tpknam1qrv9rr5gja9qd352hmhxlgxarm2zedkm7mveegatu6fw9gnfe72rxdpca4c = "signam1qq3qy9mjc3mhs9f67l00y2p5w2edfq05ql0w8e22tt2gpxs78h83hsjg4nhkx9lgt2k76jklzj9naujyvsfjux0r4uytmckgv7mnt3c29glgkf"
+
+[[bond]]
+source = "tpknam1qzwlw0a90lezuhgg2vk232ck63nqymkp3s78f48r6xc5yvpwyfrluwmg0yz"
+validator = "tnam1q8azt2cpqmc6tr2gvg5v62e4jr0t9327yupaf595"
+amount = "80"
+
+[bond.signatures]
+tpknam1qzwlw0a90lezuhgg2vk232ck63nqymkp3s78f48r6xc5yvpwyfrluwmg0yz = "signam1qzjt790dwltdu5mc73n2jf8hg8u8ljdp5yduvvjzhaf0yun8m8a39lqx60r9rgc8adre473p04n8ghjekwkwl8clz4z95c6tgkwtyhqd6ad4xa"
+
+[[bond]]
+source = "tpknam1qzwlw0a90lezuhgg2vk232ck63nqymkp3s78f48r6xc5yvpwyfrluwmg0yz"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "20"
+
+[bond.signatures]
+tpknam1qzwlw0a90lezuhgg2vk232ck63nqymkp3s78f48r6xc5yvpwyfrluwmg0yz = "signam1qrexcga2sce7cf3rv2nkm35wxpp0lrxlqvh2sswjkp06kpse0h3xs5rq5j8m8yp4ec9zwzvnnhn6739qdteny7w5tzd0rz78nfy2pngts60rl6"
+
+[[bond]]
+source = "tpknam1qr5w2nede9zecmp3vvsw7lqxvwfy9muzm8njg69g9wcn8c37exy2q3pxl4j"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "105"
+
+[bond.signatures]
+tpknam1qr5w2nede9zecmp3vvsw7lqxvwfy9muzm8njg69g9wcn8c37exy2q3pxl4j = "signam1qpkaj59v45rl3hlj04kywvc4kyeaymz4j0lks4360axe2regrrve9zyyc8d0aav4u4accuwq0v0s7kpp35pr423z90dp3rqvtlvr7ug04g48mz"
+
+[[bond]]
+source = "tpknam1qzdnlj9cq5jvue0y6ejs5ch2nd6nhn0u3v580gpah8lanuwxxyew6zrwukz"
+validator = "tnam1q8xasrt0q8qrkqj5s9r9xw3ee0gx5mqwyukhe699"
+amount = "40"
+
+[bond.signatures]
+tpknam1qzdnlj9cq5jvue0y6ejs5ch2nd6nhn0u3v580gpah8lanuwxxyew6zrwukz = "signam1qqj9c73zcv0cd27pyj4ecvh7rm3p3v7aev3uldqttj6h4s0hjumavt5auy5wk9l3wnhys9xxrg4t63ks9hkyj0rsjtpr92ajqjsd90cxl6pv2z"
+
+[[bond]]
+source = "tpknam1qpqtz09ul58knwd4qujfltf6qyakcfhemmcnusr49u5t9zsdl2jfku9dz2w"
+validator = "tnam1q9pt4hukg0ga362jq2slhg4tuf692zqqngzzz54k"
+amount = "1100"
+
+[bond.signatures]
+tpknam1qpqtz09ul58knwd4qujfltf6qyakcfhemmcnusr49u5t9zsdl2jfku9dz2w = "signam1qqgmh92p7k932ztl68yq2km5nhzztsvklwsgddlk7jklwlvrkywr7vek98j9nu7y8vtvs0w6x5y45jqf9r72g7chl7uzm6nnplwmwjgp9k0d6e"
+
+[[bond]]
+source = "tpknam1qz8magrh9cs5xpws55x9urmwxfkvsc40qmwjjdatr9gh9mnfanhg57purqf"
+validator = "tnam1q89xnpnrfsefr9ynj4v8ngdu35me8xudzgn94afm"
+amount = "1023"
+
+[bond.signatures]
+tpknam1qz8magrh9cs5xpws55x9urmwxfkvsc40qmwjjdatr9gh9mnfanhg57purqf = "signam1qrhagxuucnxg37kevxpt3plh8thhw0rsqnn9qzj35kcq67dpj6hn4qtvhtr3lepcv3rulp7mlxp3wy83g9tglhgsg25fw2mzwlhd2wcga4z7dq"
+
+[[bond]]
+source = "tpknam1qzxwxrzns2m4fks4uhxnytulnza2w3mt97tlj5w37jgq06gparaygq4al4d"
+validator = "tnam1qxepvwg3c24kv0ltlkaasxscy3fsk89h8vrwzgd7"
+amount = "907"
+
+[bond.signatures]
+tpknam1qzxwxrzns2m4fks4uhxnytulnza2w3mt97tlj5w37jgq06gparaygq4al4d = "signam1qzkc598g3patdmedmph60eqsgdnryctystr4f00622sc259hxmefcdk87gjeup0vvmazlfu7dl5wkv2m82gn8fyznuhgrsecxugnz5qfgcgwyu"
+
+[[bond]]
+source = "tpknam1qzxwxrzns2m4fks4uhxnytulnza2w3mt97tlj5w37jgq06gparaygq4al4d"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "225.8"
+
+[bond.signatures]
+tpknam1qzxwxrzns2m4fks4uhxnytulnza2w3mt97tlj5w37jgq06gparaygq4al4d = "signam1qr5xjczx9x75r7yqg6mgcycdn6wa9458trv2zm5suauyke8vxnh3cvxhexcdt9qy0zv4tfwjmmk53h40ezasr0jhndtnc7w53jsqsvqfwk50r2"
+
+[[bond]]
+source = "tpknam1qqnnqdyzw62z57wttwpmw7xtw5neasr0ce2grlnudeuwcxdnpexmztnrrk4"
+validator = "tnam1q8azt2cpqmc6tr2gvg5v62e4jr0t9327yupaf595"
+amount = "108"
+
+[bond.signatures]
+tpknam1qqnnqdyzw62z57wttwpmw7xtw5neasr0ce2grlnudeuwcxdnpexmztnrrk4 = "signam1qqszj8yrr0sgschncrjy33u0ftp594a7m25xe2653kukcujr8wddnx6fpa29pu207sfnfzevtyrv0qya0t0t7datvz5rk6258jmyzqqfndjq9r"
+
+[[bond]]
+source = "tpknam1qqnnqdyzw62z57wttwpmw7xtw5neasr0ce2grlnudeuwcxdnpexmztnrrk4"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "27"
+
+[bond.signatures]
+tpknam1qqnnqdyzw62z57wttwpmw7xtw5neasr0ce2grlnudeuwcxdnpexmztnrrk4 = "signam1qr9xf55hemsycght3s43c6mskavrwz5daakxg466a6k4wu0dmryn3mvh85nqkfh6qw0guzguw25gdj2kf42w9gwx4f88j98qhxa8pesqt6vm74"
+
+[[bond]]
+source = "tpknam1qpjp2efk3c0epgs9tgqgek2zqng7c3cd6qhsk9szjhjllvtu7zl9x73uqn2"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "300"
+
+[bond.signatures]
+tpknam1qpjp2efk3c0epgs9tgqgek2zqng7c3cd6qhsk9szjhjllvtu7zl9x73uqn2 = "signam1qqx8l9sgza4kn9jk602kndqk3tqyc9xtqdqgkhx8xj70uzvdlew6pf0m5t426x55xv6d66dnwr4ugk0tpwdyh5g72fva2jkvu5k96ss9jdrvmv"
+
+[[bond]]
+source = "tpknam1qpf5xrsrsjc67f7e3ehh8cnw37dahzg76j2yrnxa5ggrrhn270wvvu5vqxl"
+validator = "tnam1q89xnpnrfsefr9ynj4v8ngdu35me8xudzgn94afm"
+amount = "1923"
+
+[bond.signatures]
+tpknam1qpf5xrsrsjc67f7e3ehh8cnw37dahzg76j2yrnxa5ggrrhn270wvvu5vqxl = "signam1qr34np420aqhsqnwahhnzrh0hfnhlhdymjxna7qdermmet33reqxk7j0ejx74mwn90lluekznvh03mgcnv7nuqtshczedvg4p04wjlqzymnlyw"
+
+[[bond]]
+source = "tpknam1qpwyvvd6eqj49mr2sp7l4lmdgf6rls8zy2nh7maqfvgrt64fy3ypgpnzm43"
+validator = "tnam1q9pt4hukg0ga362jq2slhg4tuf692zqqngzzz54k"
+amount = "105"
+
+[bond.signatures]
+tpknam1qpwyvvd6eqj49mr2sp7l4lmdgf6rls8zy2nh7maqfvgrt64fy3ypgpnzm43 = "signam1qqaac8vnzk330fyakqj57qdu84pcr465nfhtxj0gzqvdr56w2ltstty4uqeldps9vcneaptrxdrew5tt6gyyv3zp3kqssdcjmmg2gfsx834f9l"
+
+[[bond]]
+source = "tpknam1qpmew0u8ux0wknzneg7mvj7ndcqn39nv7sarygva4h6znq3geg76yxafp6p"
+validator = "tnam1q9sdarpylwxd5vv3e8u6wstrpz052jhls5g4a3wg"
+amount = "110"
+
+[bond.signatures]
+tpknam1qpmew0u8ux0wknzneg7mvj7ndcqn39nv7sarygva4h6znq3geg76yxafp6p = "signam1qq9wervnrq40esy3d7u85l4pqdhfgkklaqee2xxczdk6ym5paghcrfnv62tqpyjtqldqyevdrtwcq0sdel8s5lkg9jz4sxc0up43mucw0qdw8m"
+
+[[bond]]
+source = "tpknam1qqk3udywr2h8v82jlrlvdmyu9w7xhl4kz5909h26xfqf7kfa6kkhytemeds"
+validator = "tnam1q9vrp45qtphed4q2vc382qrtf2gfykf50vssfe2h"
+amount = "140"
+
+[bond.signatures]
+tpknam1qqk3udywr2h8v82jlrlvdmyu9w7xhl4kz5909h26xfqf7kfa6kkhytemeds = "signam1qpq78rx9she6rpr4nka3q3gslxm2frck6xlekks9kdqyel4j5dwkzak038ded8f2yzmeeapfj0qjs93snzyk75a5aaraw4f2mhnrz3cgrjajyt"
+
+[[bond]]
+source = "tpknam1qpsmxaxtp4cl30j9uy7h5cqn342fxm2cescw4fm47wwltuhaustz2mtxnhm"
+validator = "tnam1qxzwta6uhcsv40a8l4g5t07q0ey50c9dlyt3s272"
+amount = "15000"
+
+[bond.signatures]
+tpknam1qpsmxaxtp4cl30j9uy7h5cqn342fxm2cescw4fm47wwltuhaustz2mtxnhm = "signam1qzhes5ransqcc8tsaxk7ay3nyj7j3myxuszppre4m2e25ag2vng4h7c9zgtlcu78wvpu6xsz69zg3mqhfjegrnlvdm08s0szhvlk37c9l5hmzx"
+
+[[bond]]
+source = "tpknam1qp05flshuxf5r55l3wtgllsrn0qus9aym76z0wklf7q6t437vs5xvxs0dlc"
+validator = "tnam1q8azt2cpqmc6tr2gvg5v62e4jr0t9327yupaf595"
+amount = "193"
+
+[bond.signatures]
+tpknam1qp05flshuxf5r55l3wtgllsrn0qus9aym76z0wklf7q6t437vs5xvxs0dlc = "signam1qr5sr2w6cg3yu8ljs4np99jr08s7hfxhwv5dwzx86qw4walpd5s03ngxl749xt455dnj4h3s2caknkh79ffzgt8n49naet9u4wm8zlqz605pd6"
+
+[[bond]]
+source = "tpknam1qp05flshuxf5r55l3wtgllsrn0qus9aym76z0wklf7q6t437vs5xvxs0dlc"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "48"
+
+[bond.signatures]
+tpknam1qp05flshuxf5r55l3wtgllsrn0qus9aym76z0wklf7q6t437vs5xvxs0dlc = "signam1qr5um0kaqkn75utlwpjleepwdfdq6stlq06k4kv824r0ep0p8jky7zzg8z90rdg6ys8pq8yfxecz79mkdag8dg76z6na9cnyljs3hpc8g05vkl"
+
+[[bond]]
+source = "tpknam1qqyr9wwguzd0mk3g8nnyjazcys0u4vyznfkw6485t946a0z395w6s5e2xv0"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "130"
+
+[bond.signatures]
+tpknam1qqyr9wwguzd0mk3g8nnyjazcys0u4vyznfkw6485t946a0z395w6s5e2xv0 = "signam1qqyhk264cgc8vjckddzksdl6qapee6jew2aahgw0prm8eaf0dd6yv4zemwysydgkhyqwcm4kfrxwxx8e4ywjxru6h3yht3hk0lz6fug2zcqhg7"
+
+[[bond]]
+source = "tpknam1qpsqsv7nsy0e3dhzngmckj9nnygevsqjjclu3amajqzg5edlx4g5z33u38s"
+validator = "tnam1qy6y8ws67ks2p5jl53s6yukre554mhwrugdp8vjh"
+amount = "104"
+
+[bond.signatures]
+tpknam1qpsqsv7nsy0e3dhzngmckj9nnygevsqjjclu3amajqzg5edlx4g5z33u38s = "signam1qprxh2y6gx983yel3us9zrat6phswj7kds904lhysf4ujrr9xwef86k89pxd9vjxyqnlyszp569wzmj42h0ek4036v085hsfqng6txq98l8clg"
+
+[[bond]]
+source = "tpknam1qpsqsv7nsy0e3dhzngmckj9nnygevsqjjclu3amajqzg5edlx4g5z33u38s"
+validator = "tnam1qydvhqdu2q2vrgvju2ngpt6yhrehu525pus6m28p"
+amount = "26"
+
+[bond.signatures]
+tpknam1qpsqsv7nsy0e3dhzngmckj9nnygevsqjjclu3amajqzg5edlx4g5z33u38s = "signam1qp7w8ax04vccaf03ma4hmkjnxtkngqzd6euwmaajrrml6s8h7r0l70d6n9v95smqusxp6wjkjcuv6cfd5ps7e3udpurufa5vf7hjulsyhzz0zd"
+
+[[bond]]
+source = "tpknam1qr9mzuc0hfewz4rawxmn7v04q5d50h4mle54fhw7m2fwl2xx25fdyv74qdt"
+validator = "tnam1qygyng6guhgj7jy4cfe2pxmsle6sakcvqv3cnlg6"
+amount = "130"
+
+[bond.signatures]
+tpknam1qr9mzuc0hfewz4rawxmn7v04q5d50h4mle54fhw7m2fwl2xx25fdyv74qdt = "signam1qqnad3uzus7g7fp6dlv3m49xnnaqvhhuwytjndmmz6wnl3u4p7a6mlxtjeey0wzn63xgtyk8ml29ykv3cxfcca9plgq0rl67ella2pg832v3pe"
+
+[[bond]]
+source = "tpknam1qzntkcrng00vmu2smf98gyfs6ufh2gktrkwva2d2w379v80y88cvuguwtlj"
+validator = "tnam1q80ajrpqzv0vz9sl5ye22rprjt3k3q0cqy4lwywe"
+amount = "101"
+
+[bond.signatures]
+tpknam1qzntkcrng00vmu2smf98gyfs6ufh2gktrkwva2d2w379v80y88cvuguwtlj = "signam1qqrm4qgwhgkm4t29d5pj20cuahnkk5mrefcc3ugf3y2200q2mfejdtvznfym92x504tdwxeagq7ltnhkvuf5mh4p4pcequcyzvjv5jsyktapfr"
+
+[[bond]]
+source = "tpknam1qr3ytjw60dfxfpy82rnw3nr6e8mxg3mw94pamqkqxaqfe36qhnd7c7e0s6l"
+validator = "tnam1q89xnpnrfsefr9ynj4v8ngdu35me8xudzgn94afm"
+amount = "230"
+
+[bond.signatures]
+tpknam1qr3ytjw60dfxfpy82rnw3nr6e8mxg3mw94pamqkqxaqfe36qhnd7c7e0s6l = "signam1qrak95u3396434gng3aalz992yx7tgt8dfvtp832cwq4yaesmu09ryrg722esftqhzpkl60z3cl48ce3f0fqmmv5tp6tsq5pmd3ym8cxh0kh38"


### PR DESCRIPTION
## Discord handler
dimiandre

## Description

This pr includes all the valid bonds submitted trough the [namada pre-bond genesis ui](https://namada-genesis.kintsugi-nodes.com/) with the "automatic" flag checked as of October 1st - CET evening

dimiandre-bond.toml will be updated daily to reflect bond changes from users using the ui.

It's good to merge if we want to see some new bonds in the readme charts.

I can reopen the pr every time is needed

thanks! 🫡

## Checklist before opening a pull request
- [x] My submissions follow the [instructions](https://hackmd.io/CNzB-rsNQ1ykRHkj8EDbTA?view)
- [ ] Im aware my submission will not be modifiable/delatable if merged
