### PR TITLE
Add EverlastingOps pre-genesis transactions

### DIFF
--- a/transactions/EverlastingOps-validator.toml
+++ b/transactions/EverlastingOps-validator.toml
@@ -37,3 +37,4 @@ name = "Everlasting"
 
 [validator_account.signatures]
 tpknam1qp7hnlgqzu0z022nsd3hcugjf9v97392g7l27h9slqjddsxretpf5esnyhy = "signam1qqa2lnmtlmvvygqfa4xv9pmegpy2dpwqc7jjcq729ne4ce7pwj5kc3nx5cz65xjqxeazcyscgp6jazjef7wnlr6cyn84fdg2hrep0qg2rm4jxx"
+


### PR DESCRIPTION
This modifies the metadata for the EverlastingOps validator submitted in https://github.com/anoma/namada-mainnet-genesis/pull/216/

## Discord handler
<@paulsalis>

## Checklist before opening a pull request
- [x] My submissions follow the [instructions](https://hackmd.io/CNzB-rsNQ1ykRHkj8EDbTA?view)
- [x] Im aware my submission will not be modifiable/delatable if merged
